### PR TITLE
Reimplement channels using custom LinkedList impl

### DIFF
--- a/.github/workflows/v0.yml
+++ b/.github/workflows/v0.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - run: sudo apt install valgrind jq
     - run: cargo fmt --check
     - run: cargo clippy
-    - run: cargo test
+    - run: ./test.sh

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ mod state;
 use self::linked_list::NodeRef;
 use self::state::SendWaker;
 
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 use std::ops::DerefMut;
 use std::pin::Pin;
 use std::task::{Context, Poll, Waker};
@@ -275,6 +275,15 @@ where
     T: Send + Sync + 'static,
 {
     state: State<T>,
+}
+
+impl<T> Debug for Sender<T>
+where
+    T: Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Sender")
+    }
 }
 
 /// Cloning creates new a instance with the shared state  and increases the internal reference
@@ -646,7 +655,8 @@ where
 #[cfg(test)]
 mod testing {
     use std::collections::BTreeSet;
-    // use std::time::Duration;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     use super::*;
 
@@ -658,350 +668,350 @@ mod testing {
         assert_eq!(res, 1);
     }
 
-   #[tokio::test]
-   async fn mpsc() {
-       let (tx, rx) = channel(1);
+    #[tokio::test]
+    async fn mpsc() {
+        let (tx, rx) = channel(1);
 
-       let num_workers = 10;
-       let count = 10;
-       let mut tasks = Vec::with_capacity(num_workers);
+        let num_workers = 10;
+        let count = 10;
+        let mut tasks = Vec::with_capacity(num_workers);
 
-       for i in 0..num_workers {
-           let tx = tx.clone();
-           let task = tokio::spawn(async move {
-               for j in 0..count {
-                   let val = i * count + j;
-                   tx.send(val).await.expect("Failed to send");
-               }
-           });
-           tasks.push(task);
-       }
+        for i in 0..num_workers {
+            let tx = tx.clone();
+            let task = tokio::spawn(async move {
+                for j in 0..count {
+                    let val = i * count + j;
+                    tx.send(val).await.expect("Failed to send");
+                }
+            });
+            tasks.push(task);
+        }
 
-       let total = count * num_workers;
-       let mut values = BTreeSet::new();
+        let total = count * num_workers;
+        let mut values = BTreeSet::new();
 
-       for _ in 0..total {
-           let value = rx.recv().await.expect("no error");
-           values.insert(value);
-       }
+        for _ in 0..total {
+            let value = rx.recv().await.expect("no error");
+            values.insert(value);
+        }
 
-       let exp = (0..total).collect::<Vec<_>>();
-       let got = values.into_iter().collect::<Vec<_>>();
-       assert_eq!(exp, got);
+        let exp = (0..total).collect::<Vec<_>>();
+        let got = values.into_iter().collect::<Vec<_>>();
+        assert_eq!(exp, got);
 
-       for task in tasks {
-           task.await.expect("failed to join task");
-       }
-   }
+        for task in tasks {
+            task.await.expect("failed to join task");
+        }
+    }
 
-    //    async fn run_tasks<F, Fut>(send: F)
-    //    where
-    //        Fut: Future<Output = Sender<usize>> + Send,
-    //        F: Send + Sync + 'static + Copy,
-    //        F: Fn(Sender<usize>, usize) -> Fut,
-    //    {
-    //        let (tx, rx) = channel(1);
+    async fn run_tasks<F, Fut>(send: F)
+    where
+        Fut: Future<Output = Sender<usize>> + Send,
+        F: Send + Sync + 'static + Copy,
+        F: Fn(Sender<usize>, usize) -> Fut,
+    {
+        let (tx, rx) = channel(1);
 
-    //        let num_workers = 10;
-    //        let count = 10;
-    //        let mut tasks = Vec::with_capacity(num_workers);
+        let num_workers = 10;
+        let count = 10;
+        let mut tasks = Vec::with_capacity(num_workers);
 
-    //        for i in 0..num_workers {
-    //            let mut tx = tx.clone();
-    //            let task = tokio::spawn(async move {
-    //                for j in 0..count {
-    //                    let val = i * count + j;
-    //                    tx = send(tx, val).await;
-    //                }
-    //            });
-    //            tasks.push(task);
-    //        }
+        for i in 0..num_workers {
+            let mut tx = tx.clone();
+            let task = tokio::spawn(async move {
+                for j in 0..count {
+                    let val = i * count + j;
+                    tx = send(tx, val).await;
+                }
+            });
+            tasks.push(task);
+        }
 
-    //        let total = count * num_workers;
-    //        let values = Arc::new(Mutex::new(BTreeSet::new()));
+        let total = count * num_workers;
+        let values = Arc::new(Mutex::new(BTreeSet::new()));
 
-    //        for _ in 0..num_workers {
-    //            let values = values.clone();
-    //            let rx = rx.clone();
-    //            let task = tokio::spawn(async move {
-    //                for _ in 0..count {
-    //                    let val = rx.recv().await.expect("Failed to recv");
-    //                    values.lock().unwrap().insert(val);
-    //                }
-    //            });
-    //            tasks.push(task);
-    //        }
+        for _ in 0..num_workers {
+            let values = values.clone();
+            let rx = rx.clone();
+            let task = tokio::spawn(async move {
+                for _ in 0..count {
+                    let val = rx.recv().await.expect("Failed to recv");
+                    values.lock().unwrap().insert(val);
+                }
+            });
+            tasks.push(task);
+        }
 
-    //        for task in tasks {
-    //            task.await.expect("failed to join task");
-    //        }
+        for task in tasks {
+            task.await.expect("failed to join task");
+        }
 
-    //        let exp = (0..total).collect::<Vec<_>>();
-    //        let got = std::mem::take(values.lock().unwrap().deref_mut())
-    //            .into_iter()
-    //            .collect::<Vec<_>>();
-    //        assert_eq!(exp, got);
-    //    }
+        let exp = (0..total).collect::<Vec<_>>();
+        let got = std::mem::take(values.lock().unwrap().deref_mut())
+            .into_iter()
+            .collect::<Vec<_>>();
+        assert_eq!(exp, got);
+    }
 
-    //    #[tokio::test]
-    //    async fn mpmc_multiple_tasks() {
-    //        run_tasks(|tx, value| async move {
-    //            tx.send(value).await.expect("Failed to send");
-    //            tx
-    //        })
-    //        .await;
-    //    }
+    #[tokio::test]
+    async fn mpmc_multiple_tasks() {
+        run_tasks(|tx, value| async move {
+            tx.send(value).await.expect("Failed to send");
+            tx
+        })
+        .await;
+    }
 
-    //    #[tokio::test]
-    //    async fn mpmc_reserve() {
-    //        run_tasks(|tx, value| async move {
-    //            tx.reserve().await.expect("Failed to send").send(value);
-    //            tx
-    //        })
-    //        .await;
-    //    }
+    #[tokio::test]
+    async fn mpmc_reserve() {
+        run_tasks(|tx, value| async move {
+            tx.reserve().await.expect("Failed to send").send(value);
+            tx
+        })
+        .await;
+    }
 
-    //    #[tokio::test]
-    //    async fn mpmc_try_reserve() {
-    //        run_tasks(|tx, value| async move {
-    //            loop {
-    //                match tx.try_reserve() {
-    //                    Ok(permit) => {
-    //                        permit.send(value);
-    //                    }
-    //                    Err(_err) => {
-    //                        tokio::time::sleep(Duration::ZERO).await;
-    //                        continue;
-    //                    }
-    //                };
+    #[tokio::test]
+    async fn mpmc_try_reserve() {
+        run_tasks(|tx, value| async move {
+            loop {
+                match tx.try_reserve() {
+                    Ok(permit) => {
+                        permit.send(value);
+                    }
+                    Err(_err) => {
+                        tokio::time::sleep(Duration::ZERO).await;
+                        continue;
+                    }
+                };
 
-    //                return tx;
-    //            }
-    //        })
-    //        .await;
-    //    }
+                return tx;
+            }
+        })
+        .await;
+    }
 
-    //    #[tokio::test]
-    //    async fn send_errors() {
-    //        let (tx, rx) = channel::<i32>(2);
-    //        assert_eq!(tx.send(1).await, Ok(()));
-    //        assert_eq!(tx.send(2).await, Ok(()));
-    //        let task = tokio::spawn({
-    //            let tx = tx.clone();
-    //            async move { tx.send(3).await }
-    //        });
-    //        drop(rx);
-    //        assert_eq!(tx.send(4).await, Err(SendError(4)));
-    //        assert_eq!(task.await.expect("panic"), Err(SendError(3)));
-    //    }
+    #[tokio::test]
+    async fn send_errors() {
+        let (tx, rx) = channel::<i32>(2);
+        assert_eq!(tx.send(1).await, Ok(()));
+        assert_eq!(tx.send(2).await, Ok(()));
+        let task = tokio::spawn({
+            let tx = tx.clone();
+            async move { tx.send(3).await }
+        });
+        drop(rx);
+        assert_eq!(tx.send(4).await, Err(SendError(4)));
+        assert_eq!(task.await.expect("panic"), Err(SendError(3)));
+    }
 
-    //    #[test]
-    //    fn try_send_errors() {
-    //        let (tx, rx) = channel::<i32>(2);
-    //        assert_eq!(tx.try_send(1), Ok(()));
-    //        assert_eq!(tx.try_send(2), Ok(()));
-    //        assert_eq!(tx.try_send(3), Err(TrySendError::Full(3)));
-    //        assert_eq!(tx.try_send(4), Err(TrySendError::Full(4)));
-    //        drop(rx);
-    //        assert_eq!(tx.try_send(5), Err(TrySendError::Disconnected(5)));
-    //    }
+    #[test]
+    fn try_send_errors() {
+        let (tx, rx) = channel::<i32>(2);
+        assert_eq!(tx.try_send(1), Ok(()));
+        assert_eq!(tx.try_send(2), Ok(()));
+        assert_eq!(tx.try_send(3), Err(TrySendError::Full(3)));
+        assert_eq!(tx.try_send(4), Err(TrySendError::Full(4)));
+        drop(rx);
+        assert_eq!(tx.try_send(5), Err(TrySendError::Disconnected(5)));
+    }
 
-    //    #[tokio::test]
-    //    async fn reserve_errors() {
-    //        let (tx, rx) = channel::<i32>(2);
-    //        tx.reserve().await.expect("reserved 1");
-    //        tx.reserve().await.expect("reserved 2");
-    //        let task = tokio::spawn({
-    //            let tx = tx.clone();
-    //            async move {
-    //                assert!(matches!(tx.reserve().await, Err(ReserveError)));
-    //            }
-    //        });
-    //        drop(rx);
-    //        assert!(matches!(tx.reserve().await, Err(ReserveError)));
-    //        task.await.expect("no panic");
-    //    }
+    #[tokio::test]
+    async fn reserve_errors() {
+        let (tx, rx) = channel::<i32>(2);
+        tx.reserve().await.expect("reserved 1");
+        tx.reserve().await.expect("reserved 2");
+        let task = tokio::spawn({
+            let tx = tx.clone();
+            async move {
+                assert!(matches!(tx.reserve().await, Err(ReserveError)));
+            }
+        });
+        drop(rx);
+        assert!(matches!(tx.reserve().await, Err(ReserveError)));
+        task.await.expect("no panic");
+    }
 
-    //    #[test]
-    //    fn try_reserve_errors() {
-    //        let (tx, rx) = channel::<i32>(2);
-    //        let _res1 = tx.try_reserve().expect("reserved 1");
-    //        let _res2 = tx.try_reserve().expect("reserved 2");
-    //        assert!(matches!(tx.try_reserve(), Err(TryReserveError::Full)));
-    //        assert!(matches!(tx.try_reserve(), Err(TryReserveError::Full)));
-    //        drop(rx);
-    //        assert!(matches!(
-    //            tx.try_reserve(),
-    //            Err(TryReserveError::Disconnected)
-    //        ));
-    //    }
+    #[test]
+    fn try_reserve_errors() {
+        let (tx, rx) = channel::<i32>(2);
+        let _res1 = tx.try_reserve().expect("reserved 1");
+        let _res2 = tx.try_reserve().expect("reserved 2");
+        assert!(matches!(tx.try_reserve(), Err(TryReserveError::Full)));
+        assert!(matches!(tx.try_reserve(), Err(TryReserveError::Full)));
+        drop(rx);
+        assert!(matches!(
+            tx.try_reserve(),
+            Err(TryReserveError::Disconnected)
+        ));
+    }
 
-    //    #[tokio::test]
-    //    async fn recv_future_awoken_but_unused() {
-    //        let (tx, rx) = channel::<i32>(1);
-    //        let mut recv = Box::pin(rx.recv());
-    //        let rx2 = rx.clone();
-    //        // Try receiving from rx2, but don't drop it yet.
-    //        tokio::select! {
-    //            biased;
-    //            _ = &mut recv => {
-    //                panic!("unexpected recv");
-    //            }
-    //            _ = ReadyFuture {} => {}
-    //        }
-    //        let task = tokio::spawn(async move { rx2.recv().await });
-    //        // Yield the current task so task above can be started.
-    //        tokio::time::sleep(Duration::ZERO).await;
-    //        tx.try_send(1).expect("sent");
-    //        // It would hang without the drop, since the recv would be awoken, but we'd never await for
-    //        // it. This is the main flaw of this design where only a single future is awoken at the
-    //        // time. Alternatively, we could wake all of them at once, but this would most likely
-    //        // result in performance degradation due to lock contention.
-    //        drop(recv);
-    //        let res = task.await.expect("no panic").expect("receivd");
-    //        assert_eq!(res, 1);
-    //    }
+    // #[tokio::test]
+    // async fn recv_future_awoken_but_unused() {
+    //     let (tx, rx) = channel::<i32>(1);
+    //     let mut recv = Box::pin(rx.recv());
+    //     let rx2 = rx.clone();
+    //     // Try receiving from rx2, but don't drop it yet.
+    //     tokio::select! {
+    //         biased;
+    //         _ = &mut recv => {
+    //             panic!("unexpected recv");
+    //         }
+    //         _ = ReadyFuture {} => {}
+    //     }
+    //     let task = tokio::spawn(async move { rx2.recv().await });
+    //     // Yield the current task so task above can be started.
+    //     tokio::time::sleep(Duration::ZERO).await;
+    //     tx.try_send(1).expect("sent");
+    //     // It would hang without the drop, since the recv would be awoken, but we'd never await for
+    //     // it. This is the main flaw of this design where only a single future is awoken at the
+    //     // time. Alternatively, we could wake all of them at once, but this would most likely
+    //     // result in performance degradation due to lock contention.
+    //     drop(recv);
+    //     let res = task.await.expect("no panic").expect("receivd");
+    //     assert_eq!(res, 1);
+    // }
 
-    //    #[tokio::test]
-    //    async fn try_reserve_unused_permit_and_send() {
-    //        let (tx, rx) = channel::<i32>(1);
-    //        let permit = tx.try_reserve().expect("reserved");
-    //        let task = tokio::spawn({
-    //            let tx = tx.clone();
-    //            async move { tx.send(1).await }
-    //        });
-    //        drop(permit);
-    //        task.await.expect("no panic").expect("sent");
-    //        assert_eq!(rx.try_recv().expect("recv"), 1);
-    //    }
+    #[tokio::test]
+    async fn try_reserve_unused_permit_and_send() {
+        let (tx, rx) = channel::<i32>(1);
+        let permit = tx.try_reserve().expect("reserved");
+        let task = tokio::spawn({
+            let tx = tx.clone();
+            async move { tx.send(1).await }
+        });
+        drop(permit);
+        task.await.expect("no panic").expect("sent");
+        assert_eq!(rx.try_recv().expect("recv"), 1);
+    }
 
-    //    #[tokio::test]
-    //    async fn try_reserve_unused_permit_and_other_permit() {
-    //        let (tx, rx) = channel::<i32>(1);
-    //        let permit = tx.try_reserve().expect("reserved");
-    //        let task = tokio::spawn({
-    //            let tx = tx.clone();
-    //            async move { tx.reserve().await.expect("reserved").send(1) }
-    //        });
-    //        drop(permit);
-    //        task.await.expect("no panic");
-    //        assert_eq!(rx.try_recv().expect("recv"), 1);
-    //    }
+    #[tokio::test]
+    async fn try_reserve_unused_permit_and_other_permit() {
+        let (tx, rx) = channel::<i32>(1);
+        let permit = tx.try_reserve().expect("reserved");
+        let task = tokio::spawn({
+            let tx = tx.clone();
+            async move { tx.reserve().await.expect("reserved").send(1) }
+        });
+        drop(permit);
+        task.await.expect("no panic");
+        assert_eq!(rx.try_recv().expect("recv"), 1);
+    }
 
-    //    #[tokio::test]
-    //    async fn receiver_close_all() {
-    //        let (tx, rx1) = channel::<i32>(3);
-    //        let rx2 = rx1.clone();
-    //        let permit1 = tx.reserve().await.unwrap();
-    //        let permit2 = tx.reserve().await.unwrap();
-    //        tx.send(1).await.unwrap();
-    //        rx1.close_all();
-    //        assert_eq!(rx1.recv().await.unwrap(), 1);
-    //        assert_no_recv(&rx1).await;
-    //        assert_no_recv(&rx2).await;
-    //        permit1.send(2);
-    //        permit2.send(3);
-    //        assert_eq!(rx1.recv().await.unwrap(), 2);
-    //        assert_eq!(rx2.try_recv().unwrap(), 3);
-    //        assert_eq!(rx1.recv().await, Err(RecvError));
-    //        assert_eq!(rx2.recv().await, Err(RecvError));
-    //        assert!(matches!(tx.send(3).await, Err(SendError(3))));
-    //    }
+    #[tokio::test]
+    async fn receiver_close_all() {
+        let (tx, rx1) = channel::<i32>(3);
+        let rx2 = rx1.clone();
+        let permit1 = tx.reserve().await.unwrap();
+        let permit2 = tx.reserve().await.unwrap();
+        tx.send(1).await.unwrap();
+        rx1.close_all();
+        assert_no_recv(&rx1).await;
+        assert_no_recv(&rx2).await;
+        permit1.send(2);
+        permit2.send(3);
+        assert_eq!(rx1.recv().await.unwrap(), 2);
+        assert_eq!(rx2.try_recv().unwrap(), 3);
+        assert_eq!(rx1.recv().await.unwrap(), 1);
+        assert_eq!(rx1.recv().await, Err(RecvError));
+        assert_eq!(rx2.recv().await, Err(RecvError));
+        assert!(matches!(tx.send(3).await, Err(SendError(3))));
+    }
 
-    //    #[tokio::test]
-    //    async fn receiver_close_all_permit_drop() {
-    //        let (tx, rx) = channel::<i32>(3);
-    //        let permit = tx.reserve().await.unwrap();
-    //        rx.close_all();
-    //        assert_no_recv(&rx).await;
-    //        drop(permit);
-    //        assert_eq!(rx.recv().await, Err(RecvError));
-    //    }
+    #[tokio::test]
+    async fn receiver_close_all_permit_drop() {
+        let (tx, rx) = channel::<i32>(3);
+        let permit = tx.reserve().await.unwrap();
+        rx.close_all();
+        assert_no_recv(&rx).await;
+        drop(permit);
+        assert_eq!(rx.recv().await, Err(RecvError));
+    }
 
-    //    #[tokio::test]
-    //    async fn reserve_owned() {
-    //        let (tx, rx) = channel::<usize>(4);
-    //        let tx = tx.reserve_owned().await.unwrap().send(1);
-    //        let tx = tx.reserve_owned().await.unwrap().send(2);
-    //        let tx = tx.try_reserve_owned().unwrap().send(3);
-    //        let tx = tx.try_reserve_owned().unwrap().release();
-    //        let tx = tx.try_reserve_owned().unwrap().send(4);
-    //        assert!(matches!(
-    //            tx.clone().try_reserve_owned(),
-    //            Err(TrySendError::Full(_))
-    //        ));
-    //        for i in 1..=4 {
-    //            assert_eq!(rx.try_recv().unwrap(), i);
-    //        }
-    //        drop(rx);
-    //        assert!(matches!(
-    //            tx.clone().reserve_owned().await,
-    //            Err(ReserveError)
-    //        ));
-    //        assert!(matches!(
-    //            tx.try_reserve_owned(),
-    //            Err(TrySendError::Disconnected(_))
-    //        ));
-    //    }
+    #[tokio::test]
+    async fn reserve_owned() {
+        let (tx, rx) = channel::<usize>(4);
+        let tx = tx.reserve_owned().await.unwrap().send(1);
+        let tx = tx.reserve_owned().await.unwrap().send(2);
+        let tx = tx.try_reserve_owned().unwrap().send(3);
+        let tx = tx.try_reserve_owned().unwrap().release();
+        let tx = tx.try_reserve_owned().unwrap().send(4);
+        assert!(matches!(
+            tx.clone().try_reserve_owned(),
+            Err(TrySendError::Full(_))
+        ));
+        for i in 1..=4 {
+            assert_eq!(rx.try_recv().unwrap(), i);
+        }
+        drop(rx);
+        assert!(matches!(
+            tx.clone().reserve_owned().await,
+            Err(ReserveError)
+        ));
+        assert!(matches!(
+            tx.try_reserve_owned(),
+            Err(TrySendError::Disconnected(_))
+        ));
+    }
 
-    //    #[tokio::test]
-    //    async fn reserve_many() {
-    //        let (tx, rx) = channel::<usize>(10);
-    //        let p1 = tx.reserve_many(5).await.unwrap();
-    //        let p2 = tx.try_reserve_many(5).unwrap();
-    //        assert!(matches!(tx.try_send(11), Err(TrySendError::Full(11))));
-    //        for (i, p) in p1.enumerate() {
-    //            p.send(i);
-    //        }
-    //        for (i, p) in p2.enumerate() {
-    //            p.send(i + 5);
-    //        }
-    //        for i in 0..10 {
-    //            assert_eq!(rx.try_recv().unwrap(), i);
-    //        }
-    //    }
+    #[tokio::test]
+    async fn reserve_many() {
+        let (tx, rx) = channel::<usize>(10);
+        let p1 = tx.reserve_many(5).await.unwrap();
+        let p2 = tx.try_reserve_many(5).unwrap();
+        assert!(matches!(tx.try_send(11), Err(TrySendError::Full(11))));
+        for (i, p) in p2.enumerate() {
+            p.send(i + 5);
+        }
+        for (i, p) in p1.enumerate() {
+            p.send(i);
+        }
+        for i in 0..10 {
+            assert_eq!(rx.try_recv().unwrap(), i);
+        }
+    }
 
-    //    #[tokio::test]
-    //    async fn reserve_many_drop() {
-    //        let (tx, _rx) = channel::<usize>(2);
-    //        let it = tx.reserve_many(2).await.unwrap();
-    //        drop(it);
-    //        tx.try_send(1).unwrap();
-    //        tx.try_send(2).unwrap();
-    //        assert!(matches!(tx.try_send(3), Err(TrySendError::Full(3))));
-    //    }
+    #[tokio::test]
+    async fn reserve_many_drop() {
+        let (tx, _rx) = channel::<usize>(2);
+        let it = tx.reserve_many(2).await.unwrap();
+        drop(it);
+        tx.try_send(1).unwrap();
+        tx.try_send(2).unwrap();
+        assert!(matches!(tx.try_send(3), Err(TrySendError::Full(3))));
+    }
 
-    //    #[tokio::test]
-    //    async fn reserve_many_drop_halfway() {
-    //        let (tx, _rx) = channel::<usize>(4);
-    //        let mut it = tx.reserve_many(4).await.unwrap();
-    //        it.next().unwrap().send(1);
-    //        it.next().unwrap().send(2);
-    //        drop(it);
-    //        tx.try_send(3).unwrap();
-    //        tx.try_send(4).unwrap();
-    //        assert!(matches!(tx.try_send(5), Err(TrySendError::Full(5))));
-    //    }
+    #[tokio::test]
+    async fn reserve_many_drop_halfway() {
+        let (tx, _rx) = channel::<usize>(4);
+        let mut it = tx.reserve_many(4).await.unwrap();
+        it.next().unwrap().send(1);
+        it.next().unwrap().send(2);
+        drop(it);
+        tx.try_send(3).unwrap();
+        tx.try_send(4).unwrap();
+        assert!(matches!(tx.try_send(5), Err(TrySendError::Full(5))));
+    }
 
-    //    async fn assert_no_recv<T>(rx: &Receiver<T>)
-    //    where
-    //        T: std::fmt::Debug + Send + Sync + 'static,
-    //    {
-    //        tokio::select! {
-    //            result = rx.recv() => {
-    //                panic!("unexpected recv: {result:?}");
-    //            },
-    //            _ = tokio::time::sleep(std::time::Duration::ZERO) => {},
-    //        }
-    //    }
+    async fn assert_no_recv<T>(rx: &Receiver<T>)
+    where
+        T: std::fmt::Debug + Send + Sync + 'static,
+    {
+        tokio::select! {
+            result = rx.recv() => {
+                panic!("unexpected recv: {result:?}");
+            },
+            _ = tokio::time::sleep(std::time::Duration::ZERO) => {},
+        }
+    }
 
-    //    struct ReadyFuture {}
+    struct ReadyFuture {}
 
-    //    impl Future for ReadyFuture {
-    //        type Output = ();
+    impl Future for ReadyFuture {
+        type Output = ();
 
-    //        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-    //            Poll::Ready(())
-    //        }
-    //    }
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Ready(())
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -567,7 +567,6 @@ where
     }
 }
 
-
 struct RecvFuture<'a, T>
 where
     T: Send + Sync + 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@
 //!     assert_eq!(exp, got);
 //! });
 //! ```
+mod linked_list;
+
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt::Display;
 use std::ops::DerefMut;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1442 +1,1482 @@
-//! A multi-producer, multi-consumer async channel with reservations.
-//!
-//! Example usage:
-//!
-//! ```rust
-//! tokio_test::block_on(async {
-//!     let (tx1, rx1) = mpmc_async::channel(2);
-//!
-//!     let task = tokio::spawn(async move {
-//!       let rx2 = rx1.clone();
-//!       assert_eq!(rx1.recv().await.unwrap(), 1);
-//!       assert_eq!(rx2.recv().await.unwrap(), 2);
-//!     });
-//!
-//!     let tx2 = tx1.clone();
-//!     let permit = tx1.reserve().await.unwrap();
-//!     tx2.send(1).await.unwrap();
-//!     permit.send(2);
-//!
-//!     task.await.unwrap();
-//! });
-//! ```
-//!
-//! A more complex example with multiple sender and receiver tasks:
-//!
-//! ```rust
-//! use std::collections::BTreeSet;
-//! use std::ops::DerefMut;
-//! use std::sync::{Arc, Mutex};
-//!
-//! tokio_test::block_on(async {
-//!     let (tx, rx) = mpmc_async::channel(1);
-//!
-//!     let num_workers = 10;
-//!     let count = 10;
-//!     let mut tasks = Vec::with_capacity(num_workers);
-//!
-//!     for i in 0..num_workers {
-//!         let mut tx = tx.clone();
-//!         let task = tokio::spawn(async move {
-//!             for j in 0..count {
-//!                 let val = i * count + j;
-//!                 tx.reserve().await.expect("no error").send(val);
-//!             }
-//!         });
-//!         tasks.push(task);
-//!     }
-//!
-//!     let total = count * num_workers;
-//!     let values = Arc::new(Mutex::new(BTreeSet::new()));
-//!
-//!     for _ in 0..num_workers {
-//!         let values = values.clone();
-//!         let rx = rx.clone();
-//!         let task = tokio::spawn(async move {
-//!             for _ in 0..count {
-//!                 let val = rx.recv().await.expect("Failed to recv");
-//!                 values.lock().unwrap().insert(val);
-//!             }
-//!         });
-//!         tasks.push(task);
-//!     }
-//!
-//!     for task in tasks {
-//!         task.await.expect("failed to join task");
-//!     }
-//!
-//!     let exp = (0..total).collect::<Vec<_>>();
-//!     let got = std::mem::take(values.lock().unwrap().deref_mut())
-//!         .into_iter()
-//!         .collect::<Vec<_>>();
-//!     assert_eq!(exp, got);
-//! });
-//! ```
-mod linked_list;
-
-use std::collections::{BTreeMap, VecDeque};
-use std::fmt::Display;
-use std::ops::DerefMut;
-use std::pin::Pin;
-use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll, Waker};
-
-use std::future::Future;
-
-/// Occurs when all receivers have been dropped.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub struct SendError<T>(pub T);
-
-impl<T> Display for SendError<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("Send failed: disconnected")
-    }
-}
-
-/// TrySendError occurs when the channel is empty or all receivers have been dropped.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub enum TrySendError<T> {
-    /// Channel full
-    Full(T),
-    /// Disconnected
-    Disconnected(T),
-}
-
-impl<T> Display for TrySendError<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TrySendError::Full(_) => f.write_str("Try send failed: full"),
-            TrySendError::Disconnected(_) => f.write_str("Try send failed: disconnected"),
-        }
-    }
-}
-
-/// Occurs when all receivers have been dropped.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub struct ReserveError;
-
-impl Display for ReserveError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("Reserve failed: disconnected")
-    }
-}
-
-/// Occurs when the channel is full, or all receivers have been dropped.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub enum TryReserveError {
-    /// Channel full
-    Full,
-    /// Disconnected
-    Disconnected,
-}
-
-impl Display for TryReserveError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TryReserveError::Full => f.write_str("Try send failed: full"),
-            TryReserveError::Disconnected => f.write_str("Try send failed: disconnected"),
-        }
-    }
-}
-
-/// Occurs when all senders have been dropped.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub struct RecvError;
-
-impl Display for RecvError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("Recv failed: disconnected")
-    }
-}
-
-/// Occurs when channel is empty or all senders have been dropped.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub enum TryRecvError {
-    /// Channel is empty
-    Empty,
-    /// Disconnected
-    Disconnected,
-}
-
-impl Display for TryRecvError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TryRecvError::Empty => f.write_str("Try recv failed: empty"),
-            TryRecvError::Disconnected => f.write_str("Try recv failed: disconnected"),
-        }
-    }
-}
-
-/// Creates a new bounded channel. When `cap` is 0 it will be increased to 1.
-pub fn channel<T>(mut cap: usize) -> (Sender<T>, Receiver<T>)
-where
-    T: Send + Sync + 'static,
-{
-    if cap == 0 {
-        cap = 1
-    }
-
-    let state = State {
-        inner: Arc::new(Mutex::new(InnerState {
-            buffer: VecDeque::with_capacity(cap),
-            reserved_count: 0,
-            receivers_count: 0,
-            senders_count: 0,
-            waiting_send_futures: BTreeMap::new(),
-            waiting_recv_futures: BTreeMap::new(),
-            next_waker_id: 0,
-            disconnected: false,
-        })),
-    };
-
-    (state.new_sender(), state.new_receiver())
-}
-
-/// Receives messages sent by [Sender].
-pub struct Receiver<T>
-where
-    T: Send + Sync + 'static,
-{
-    state: State<T>,
-}
-
-/// Cloning creates new a instance with the shared state  and increases the internal reference
-/// counter. It is guaranteed that a single message will be distributed to exacly one receiver
-/// future awaited after calling `recv()`.
-impl<T> Clone for Receiver<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn clone(&self) -> Self {
-        self.state.new_receiver()
-    }
-}
-
-impl<T> Receiver<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn new(state: State<T>) -> Self {
-        Self { state }
-    }
-
-    /// Disconnects all receivers from senders. The receivers will still receive all buffered
-    /// or reserved messages before returning an error, allowing a graceful teardown.
-    pub fn close_all(&self) {
-        self.state.close_all_receivers();
-    }
-
-    /// Waits until there's a message to be read and returns. Returns an error when there are no
-    /// more messages in the queue and all [Sender]s have been dropped.
-    pub async fn recv(&self) -> Result<T, RecvError> {
-        let recv = RecvFuture::new(self.state.next_waker_id(), self);
-
-        recv.await
-    }
-
-    /// Checks if there's a message to be read and returns immediately. Returns an error when the
-    /// channel is disconnected or empty.
-    pub fn try_recv(&self) -> Result<T, TryRecvError> {
-        let mut state = self.state.inner_mut();
-
-        if let Some(value) = state.buffer.pop_front() {
-            Ok(value)
-        } else if state.disconnected && state.reserved_count == 0 {
-            Err(TryRecvError::Disconnected)
-        } else {
-            Err(TryRecvError::Empty)
-        }
-    }
-
-    pub async fn recv_many(&self, vec: &mut Vec<T>, count: usize) -> Result<usize, RecvError> {
-        let recv = RecvManyFuture::new(self.state.next_waker_id(), self, vec, count);
-        recv.await
-    }
-
-    pub fn try_recv_many(&self, vec: &mut Vec<T>, count: usize) -> Result<usize, TryRecvError> {
-        let mut state = self.state.inner_mut();
-
-        if let Some(value) = state.buffer.pop_front() {
-            let mut num_received = 1;
-            vec.push(value);
-
-            for _ in 1..count {
-                match state.buffer.pop_front() {
-                    Some(value) => {
-                        vec.push(value);
-                        num_received += 1;
-                    }
-                    None => break,
-                }
-            }
-
-            Ok(num_received)
-        } else if state.disconnected && state.reserved_count == 0 {
-            Err(TryRecvError::Disconnected)
-        } else {
-            Err(TryRecvError::Empty)
-        }
-    }
-}
-
-/// The last reciever that's dropped will mark the channel as disconnected.
-impl<T> Drop for Receiver<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn drop(&mut self) {
-        self.state.drop_receiver();
-    }
-}
-
-/// Producers messages to be read by [Receiver]s.
-#[derive(Debug)]
-pub struct Sender<T>
-where
-    T: Send + Sync + 'static,
-{
-    state: State<T>,
-}
-
-/// Cloning creates new a instance with the shared state  and increases the internal reference
-/// counter.
-impl<T> Clone for Sender<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn clone(&self) -> Self {
-        self.state.new_sender()
-    }
-}
-
-impl<T> Sender<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn new(state: State<T>) -> Sender<T> {
-        Self { state }
-    }
-
-    /// Waits until the value is sent or returns an when all receivers have been dropped.
-    pub async fn send(&self, value: T) -> Result<(), SendError<T>> {
-        let send = SendFuture::new(self.state.next_waker_id(), self, value);
-
-        send.await
-    }
-
-    /// Sends without blocking or returns an when all receivers have been dropped.
-    pub fn try_send(&self, value: T) -> Result<(), TrySendError<T>> {
-        let mut state = self.state.inner_mut();
-
-        if state.disconnected {
-            return Err(TrySendError::Disconnected(value));
-        }
-
-        if state.has_room_for(1) {
-            if let Some(waker) = state.send_and_get_waker(value) {
-                drop(state);
-                waker.wake();
-            }
-            Ok(())
-        } else {
-            Err(TrySendError::Full(value))
-        }
-    }
-
-    /// Waits until a permit is reserved or returns an when all receivers have been dropped.
-    pub async fn reserve(&self) -> Result<Permit<'_, T>, ReserveError> {
-        ReserveFuture::new(self.state.next_waker_id(), &self.state, 1).await?;
-        Ok(Permit::new(self))
-    }
-
-    /// Reserves a permit or returns an when all receivers have been dropped.
-    pub fn try_reserve(&self) -> Result<Permit<'_, T>, TryReserveError> {
-        let mut state = self.state.inner_mut();
-
-        if state.disconnected {
-            return Err(TryReserveError::Disconnected);
-        }
-
-        if state.has_room_for(1) {
-            state.reserved_count += 1;
-            Ok(Permit::new(self))
-        } else {
-            Err(TryReserveError::Full)
-        }
-    }
-
-    /// Waits until multiple Permits in the queue are reserved.
-    pub async fn reserve_many(&self, count: usize) -> Result<PermitIterator<'_, T>, ReserveError> {
-        ReserveFuture::new(self.state.next_waker_id(), &self.state, count).await?;
-        Ok(PermitIterator::new(self, count))
-    }
-
-    /// Reserves multiple Permits in the queue, or errors out when there's no room.
-    pub fn try_reserve_many(&self, count: usize) -> Result<PermitIterator<'_, T>, TryReserveError> {
-        let mut state = self.state.inner_mut();
-
-        if state.disconnected {
-            return Err(TryReserveError::Disconnected);
-        }
-
-        if state.has_room_for(count) {
-            state.reserved_count += count;
-            Ok(PermitIterator::new(self, count))
-        } else {
-            Err(TryReserveError::Full)
-        }
-    }
-
-    /// Like [Sender::reserve], but takes ownership of `Sender` until sending is done.
-    pub async fn reserve_owned(self) -> Result<OwnedPermit<T>, ReserveError> {
-        ReserveFuture::new(self.state.next_waker_id(), &self.state, 1).await?;
-        Ok(OwnedPermit::new(self))
-    }
-
-    /// Reserves a permit or returns an when all receivers have been dropped.
-    pub fn try_reserve_owned(self) -> Result<OwnedPermit<T>, TrySendError<Self>> {
-        let mut state = self.state.inner_mut();
-
-        if state.disconnected {
-            drop(state);
-            return Err(TrySendError::Disconnected(self));
-        }
-
-        if state.has_room_for(1) {
-            state.reserved_count += 1;
-            drop(state);
-            Ok(OwnedPermit::new(self))
-        } else {
-            drop(state);
-            Err(TrySendError::Full(self))
-        }
-    }
-}
-
-/// The last sender that's dropped will mark the channel as disconnected.
-impl<T> Drop for Sender<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn drop(&mut self) {
-        self.state.drop_sender();
-    }
-}
-
-#[derive(Debug)]
-struct State<T> {
-    inner: Arc<Mutex<InnerState<T>>>,
-}
-
-impl<T> Clone for State<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn clone(&self) -> Self {
-        Self {
-            inner: Arc::clone(&self.inner),
-        }
-    }
-}
-
-impl<T> State<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn inner_mut(&self) -> impl DerefMut<Target = InnerState<T>> + '_ {
-        self.inner.lock().unwrap()
-    }
-
-    fn next_waker_id(&self) -> WakerId {
-        self.inner_mut().next_waker_id()
-    }
-
-    fn new_sender(&self) -> Sender<T> {
-        self.inner_mut().senders_count += 1;
-        Sender::new(self.clone())
-    }
-
-    fn new_receiver(&self) -> Receiver<T> {
-        self.inner_mut().receivers_count += 1;
-        Receiver::new(self.clone())
-    }
-
-    fn wake_all(wakers: Option<impl Iterator<Item = Waker>>) {
-        if let Some(wakers) = wakers {
-            for waker in wakers {
-                waker.wake()
-            }
-        }
-    }
-
-    fn close_all_receivers(&self) {
-        let (send_wakers, recv_wakers) = {
-            let mut inner = self.inner_mut();
-            let send_wakers = inner.mark_disconnected_and_take_send_futures();
-            // Keep receivers alive in case there are any active Permits.
-            let recv_wakers = (inner.reserved_count == 0)
-                .then(|| inner.mark_disconnected_and_take_recv_futures());
-
-            (send_wakers, recv_wakers)
-        };
-
-        Self::wake_all(Some(send_wakers));
-        Self::wake_all(recv_wakers);
-    }
-
-    fn drop_sender(&self) {
-        let wakers = {
-            let mut inner = self.inner_mut();
-            inner.senders_count -= 1;
-
-            (inner.senders_count == 0).then(|| inner.mark_disconnected_and_take_recv_futures())
-        };
-
-        Self::wake_all(wakers);
-    }
-
-    fn drop_receiver(&self) {
-        let wakers = {
-            let mut inner = self.inner_mut();
-            inner.receivers_count -= 1;
-
-            (inner.receivers_count == 0).then(|| inner.mark_disconnected_and_take_send_futures())
-        };
-
-        Self::wake_all(wakers);
-    }
-
-    fn drop_permit(&self, has_sent: bool) {
-        let waker = {
-            let mut inner = self.inner_mut();
-            inner.reserved_count -= 1;
-
-            // When the permit was not used for sending, it means a spot was freed, so we can notify
-            // one of the senders to proceed.
-            (!has_sent)
-                .then(|| inner.waiting_send_futures.pop_first())
-                .flatten()
-        };
-
-        if let Some((_, waker)) = waker {
-            waker.wake();
-        }
-    }
-
-    fn drop_send_future(&self, id: &WakerId, has_sent: bool) {
-        let waker = {
-            let mut inner = self.inner_mut();
-
-            let was_awoken = inner.waiting_send_futures.remove(id).is_some();
-
-            // Wake another sender in case this one has been awoken, but it was dropped before it
-            // managed to send anything.
-            (was_awoken && !has_sent)
-                .then(|| inner.take_one_send_future_waker())
-                .flatten()
-        };
-
-        if let Some(waker) = waker {
-            waker.wake();
-        }
-    }
-
-    fn drop_recv_future(&self, id: &WakerId, has_received: bool) {
-        let waker = {
-            let mut inner = self.inner_mut();
-            let was_awoken = inner.waiting_recv_futures.remove(id).is_none();
-
-            // Wake another receiver in case this one has been awoken, but it was dropped before it
-            // managed to receive anything.
-            if was_awoken {
-                if has_received {
-                    // If we have received, it means a spot was freed in the internal buffer, so wake
-                    // one sender.
-                    inner.take_one_send_future_waker()
-                } else {
-                    // If we have not received, it means another RecvFuture might take over.
-                    inner.take_one_recv_future_waker()
-                }
-            } else {
-                None
-            }
-        };
-
-        if let Some(waker) = waker {
-            waker.wake();
-        }
-    }
-}
-
-// TODO we need acustom impl of a LinkedList to be able to add/remove wakers, instead of using
-// WakerId.
-//
-// Moreover, currently reservations are just a counter, they don't actually take the
-// spot in the buffer, so in the case of a single consumer the result will be
-// re-ordered. We could keep an enum like this:
-//
-// ```
-// enum Spot<T> {
-//   Value(T),
-//   Reserved,
-// }
-// ```
-//
-// in the buffer so that we know we need to wait for the reservations.
-#[derive(Debug)]
-struct InnerState<T> {
-    /// Buffered messages, capacity is fixed.
-    buffer: VecDeque<T>,
-    /// Number of reserved spots for sending.
-    reserved_count: usize,
-    /// Total of created receivers.
-    receivers_count: usize,
-    /// Total of created senders.
-    senders_count: usize,
-    /// Senders waiting to send.
-    waiting_send_futures: BTreeMap<WakerId, Waker>,
-    /// Receivers waiting to receive.
-    waiting_recv_futures: BTreeMap<WakerId, Waker>,
-    /// Unique waker ID so each future can remove its own waker on Drop.
-    next_waker_id: WakerId,
-    /// False by default, true when all senders or all receivers are dropped.
-    disconnected: bool,
-}
-
-impl<T> InnerState<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn next_waker_id(&mut self) -> WakerId {
-        let waker_id = self.next_waker_id;
-        self.next_waker_id = self.next_waker_id.wrapping_add(1);
-        waker_id
-    }
-
-    fn has_room_for(&self, required_num_items: usize) -> bool {
-        let space = self.buffer.capacity() - self.buffer.len() - self.reserved_count;
-        space >= required_num_items
-    }
-
-    #[must_use]
-    fn send_and_get_waker(&mut self, value: T) -> Option<Waker> {
-        self.buffer.push_back(value);
-        self.take_one_recv_future_waker()
-    }
-
-    fn mark_disconnected_and_take_send_futures(&mut self) -> impl Iterator<Item = Waker> {
-        self.disconnected = true;
-        Self::take_all_wakers(&mut self.waiting_send_futures).into_values()
-    }
-
-    fn mark_disconnected_and_take_recv_futures(&mut self) -> impl Iterator<Item = Waker> {
-        self.disconnected = true;
-        Self::take_all_wakers(&mut self.waiting_recv_futures).into_values()
-    }
-
-    #[must_use]
-    fn take_one_send_future_waker(&mut self) -> Option<Waker> {
-        if self.has_room_for(1) {
-            Self::take_one_waker(&mut self.waiting_send_futures)
-        } else {
-            None
-        }
-    }
-
-    #[must_use]
-    fn take_one_recv_future_waker(&mut self) -> Option<Waker> {
-        if !self.buffer.is_empty() {
-            Self::take_one_waker(&mut self.waiting_recv_futures)
-        } else {
-            None
-        }
-    }
-
-    #[must_use]
-    fn take_one_waker(map: &mut BTreeMap<WakerId, Waker>) -> Option<Waker> {
-        map.pop_first().map(|(_, waker)| waker)
-    }
-
-    fn take_all_wakers(map: &mut BTreeMap<WakerId, Waker>) -> BTreeMap<WakerId, Waker> {
-        std::mem::take(map)
-    }
-}
-
-type WakerId = usize;
-
-struct SendFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    id: WakerId,
-    sender: &'a Sender<T>,
-    value: Option<T>,
-}
-
-impl<'a, T> SendFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    fn new(id: WakerId, sender: &'a Sender<T>, value: T) -> Self {
-        Self {
-            id,
-            sender,
-            value: Some(value),
-        }
-    }
-}
-
-impl<'a, T> Unpin for SendFuture<'a, T> where T: Send + Sync + 'static {}
-
-impl<'a, T> Future for SendFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    type Output = Result<(), SendError<T>>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // Already sent this value.
-        if self.value.is_none() {
-            return Poll::Ready(Ok(()));
-        }
-
-        let this = self.deref_mut();
-        let mut state = this.sender.state.inner_mut();
-
-        if state.disconnected {
-            Poll::Ready(Err(SendError(this.value.take().expect("some value"))))
-        } else if state.has_room_for(1) {
-            if let Some(waker) = state.send_and_get_waker(this.value.take().expect("some value")) {
-                drop(state);
-                waker.wake();
-            }
-            Poll::Ready(Ok(()))
-        } else {
-            state
-                .waiting_send_futures
-                .insert(this.id, cx.waker().clone());
-            Poll::Pending
-        }
-    }
-}
-
-impl<'a, T> Drop for SendFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    fn drop(&mut self) {
-        let has_sent = self.value.is_none();
-        self.sender.state.drop_send_future(&self.id, has_sent);
-    }
-}
-
-/// Permit holds a spot in the internal buffer so the message can be sent without awaiting.
-pub struct Permit<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    sender: &'a Sender<T>,
-    has_sent: bool,
-}
-
-impl<'a, T> Permit<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    fn new(sender: &'a Sender<T>) -> Self {
-        Self {
-            sender,
-            has_sent: false,
-        }
-    }
-
-    /// Writes a message to the internal buffer.
-    pub fn send(mut self, value: T) {
-        if let Some(waker) = self.sender.state.inner_mut().send_and_get_waker(value) {
-            waker.wake();
-        }
-        self.has_sent = true;
-        drop(self)
-    }
-}
-
-impl<'a, T> Drop for Permit<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    fn drop(&mut self) {
-        self.sender.state.drop_permit(self.has_sent);
-    }
-}
-
-pub struct PermitIterator<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    sender: &'a Sender<T>,
-    count: usize,
-}
-
-impl<'a, T> PermitIterator<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    pub fn new(sender: &'a Sender<T>, count: usize) -> Self {
-        Self { sender, count }
-    }
-}
-
-impl<'a, T> Iterator for PermitIterator<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    type Item = Permit<'a, T>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.count == 0 {
-            None
-        } else {
-            self.count -= 1;
-            Some(Permit::new(self.sender))
-        }
-    }
-}
-
-impl<'a, T> Drop for PermitIterator<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    fn drop(&mut self) {
-        for _ in 0..self.count {
-            self.sender.state.drop_permit(false);
-        }
-    }
-}
-
-pub struct OwnedPermit<T>
-where
-    T: Send + Sync + 'static,
-{
-    sender: Option<Sender<T>>,
-}
-
-impl<T> OwnedPermit<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn new(sender: Sender<T>) -> Self {
-        Self {
-            sender: Some(sender),
-        }
-    }
-
-    /// Writes a message to the internal buffer.
-    pub fn send(mut self, value: T) -> Sender<T> {
-        let sender = self
-            .sender
-            .take()
-            .expect("sender is only taken when permit is consumed");
-
-        if let Some(waker) = sender.state.inner_mut().send_and_get_waker(value) {
-            waker.wake();
-        }
-
-        sender.state.drop_permit(true);
-
-        sender
-    }
-
-    pub fn release(mut self) -> Sender<T> {
-        let sender = self
-            .sender
-            .take()
-            .expect("sender is only taken when permit is consumed");
-
-        sender.state.drop_permit(false);
-
-        sender
-    }
-}
-
-impl<T> Drop for OwnedPermit<T>
-where
-    T: Send + Sync + 'static,
-{
-    fn drop(&mut self) {
-        // if we haven't called send or release:
-        if let Some(sender) = &self.sender {
-            sender.state.drop_permit(false);
-        }
-    }
-}
-
-struct ReserveFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    id: WakerId,
-    state: &'a State<T>,
-    count: usize,
-    has_reserved: bool,
-}
-
-impl<'a, T> ReserveFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    fn new(id: WakerId, state: &'a State<T>, count: usize) -> Self {
-        Self {
-            id,
-            state,
-            count,
-            has_reserved: false,
-        }
-    }
-}
-
-impl<'a, T> Future for ReserveFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    type Output = Result<(), ReserveError>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if self.has_reserved {
-            panic!("ReservedFuture polled after ready");
-        }
-
-        let this = self.deref_mut();
-        let mut state = this.state.inner_mut();
-        if state.disconnected {
-            Poll::Ready(Err(ReserveError))
-        } else if state.has_room_for(this.count) {
-            this.has_reserved = true;
-            state.reserved_count += this.count;
-            Poll::Ready(Ok(()))
-        } else {
-            state
-                .waiting_send_futures
-                .insert(this.id, cx.waker().clone());
-            Poll::Pending
-        }
-    }
-}
-
-struct RecvFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    id: WakerId,
-    receiver: &'a Receiver<T>,
-    has_received: bool,
-}
-
-impl<'a, T> RecvFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    fn new(id: WakerId, receiver: &'a Receiver<T>) -> Self {
-        Self {
-            id,
-            receiver,
-            has_received: false,
-        }
-    }
-}
-
-impl<'a, T> Unpin for RecvFuture<'a, T> where T: Send + Sync + 'static {}
-
-impl<'a, T> Future for RecvFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    type Output = Result<T, RecvError>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.deref_mut();
-        let mut state = this.receiver.state.inner_mut();
-        let value = state.buffer.pop_front();
-
-        match value {
-            Some(value) => {
-                this.has_received = true;
-                Poll::Ready(Ok(value))
-            }
-            None => {
-                if state.disconnected && state.reserved_count == 0 {
-                    Poll::Ready(Err(RecvError))
-                } else {
-                    state
-                        .waiting_recv_futures
-                        .insert(this.id, cx.waker().clone());
-                    if let Some(waker) = state.take_one_send_future_waker() {
-                        drop(state);
-                        waker.wake();
-                    }
-                    Poll::Pending
-                }
-            }
-        }
-    }
-}
-
-impl<'a, T> Drop for RecvFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    fn drop(&mut self) {
-        self.receiver
-            .state
-            .drop_recv_future(&self.id, self.has_received);
-    }
-}
-
-struct RecvManyFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    id: WakerId,
-    receiver: &'a Receiver<T>,
-    vec: &'a mut Vec<T>,
-    count: usize,
-    has_received: bool,
-}
-
-impl<'a, T> RecvManyFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    fn new(id: WakerId, receiver: &'a Receiver<T>, vec: &'a mut Vec<T>, count: usize) -> Self {
-        Self {
-            id,
-            receiver,
-            vec,
-            count,
-            has_received: false,
-        }
-    }
-}
-
-impl<'a, T> Unpin for RecvManyFuture<'a, T> where T: Send + Sync + 'static {}
-
-impl<'a, T> Future for RecvManyFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    type Output = Result<usize, RecvError>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.deref_mut();
-        let mut state = this.receiver.state.inner_mut();
-
-        let value = state.buffer.pop_front();
-
-        match value {
-            Some(value) => {
-                let mut num_received = 1;
-                this.vec.push(value);
-
-                for _ in 1..this.count {
-                    match state.buffer.pop_front() {
-                        Some(value) => {
-                            this.vec.push(value);
-                            num_received += 1;
-                        }
-                        None => break,
-                    }
-                }
-
-                this.has_received = true;
-                Poll::Ready(Ok(num_received))
-            }
-            None => {
-                if state.disconnected && state.reserved_count == 0 {
-                    Poll::Ready(Err(RecvError))
-                } else {
-                    state
-                        .waiting_recv_futures
-                        .insert(this.id, cx.waker().clone());
-                    if let Some(waker) = state.take_one_send_future_waker() {
-                        drop(state);
-                        waker.wake();
-                    }
-                    Poll::Pending
-                }
-            }
-        }
-    }
-}
-
-impl<'a, T> Drop for RecvManyFuture<'a, T>
-where
-    T: Send + Sync + 'static,
-{
-    fn drop(&mut self) {
-        self.receiver
-            .state
-            .drop_recv_future(&self.id, self.has_received);
-    }
-}
-
-#[cfg(test)]
-mod testing {
-    use std::collections::BTreeSet;
-    use std::time::Duration;
-
-    use super::*;
-
-    #[tokio::test]
-    async fn send_receive() {
-        let (tx, rx) = channel(1);
-        tx.send(1).await.expect("no error");
-        let res = rx.recv().await.expect("no error");
-        assert_eq!(res, 1);
-    }
-
-    #[tokio::test]
-    async fn mpsc() {
-        let (tx, rx) = channel(1);
-
-        let num_workers = 10;
-        let count = 10;
-        let mut tasks = Vec::with_capacity(num_workers);
-
-        for i in 0..num_workers {
-            let tx = tx.clone();
-            let task = tokio::spawn(async move {
-                for j in 0..count {
-                    let val = i * count + j;
-                    tx.send(val).await.expect("Failed to send");
-                }
-            });
-            tasks.push(task);
-        }
-
-        let total = count * num_workers;
-        let mut values = BTreeSet::new();
-
-        for _ in 0..total {
-            let value = rx.recv().await.expect("no error");
-            values.insert(value);
-        }
-
-        let exp = (0..total).collect::<Vec<_>>();
-        let got = values.into_iter().collect::<Vec<_>>();
-        assert_eq!(exp, got);
-
-        for task in tasks {
-            task.await.expect("failed to join task");
-        }
-    }
-
-    async fn run_tasks<F, Fut>(send: F)
-    where
-        Fut: Future<Output = Sender<usize>> + Send,
-        F: Send + Sync + 'static + Copy,
-        F: Fn(Sender<usize>, usize) -> Fut,
-    {
-        let (tx, rx) = channel(1);
-
-        let num_workers = 10;
-        let count = 10;
-        let mut tasks = Vec::with_capacity(num_workers);
-
-        for i in 0..num_workers {
-            let mut tx = tx.clone();
-            let task = tokio::spawn(async move {
-                for j in 0..count {
-                    let val = i * count + j;
-                    tx = send(tx, val).await;
-                }
-            });
-            tasks.push(task);
-        }
-
-        let total = count * num_workers;
-        let values = Arc::new(Mutex::new(BTreeSet::new()));
-
-        for _ in 0..num_workers {
-            let values = values.clone();
-            let rx = rx.clone();
-            let task = tokio::spawn(async move {
-                for _ in 0..count {
-                    let val = rx.recv().await.expect("Failed to recv");
-                    values.lock().unwrap().insert(val);
-                }
-            });
-            tasks.push(task);
-        }
-
-        for task in tasks {
-            task.await.expect("failed to join task");
-        }
-
-        let exp = (0..total).collect::<Vec<_>>();
-        let got = std::mem::take(values.lock().unwrap().deref_mut())
-            .into_iter()
-            .collect::<Vec<_>>();
-        assert_eq!(exp, got);
-    }
-
-    #[tokio::test]
-    async fn mpmc_multiple_tasks() {
-        run_tasks(|tx, value| async move {
-            tx.send(value).await.expect("Failed to send");
-            tx
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn mpmc_reserve() {
-        run_tasks(|tx, value| async move {
-            tx.reserve().await.expect("Failed to send").send(value);
-            tx
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn mpmc_try_reserve() {
-        run_tasks(|tx, value| async move {
-            loop {
-                match tx.try_reserve() {
-                    Ok(permit) => {
-                        permit.send(value);
-                    }
-                    Err(_err) => {
-                        tokio::time::sleep(Duration::ZERO).await;
-                        continue;
-                    }
-                };
-
-                return tx;
-            }
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn send_errors() {
-        let (tx, rx) = channel::<i32>(2);
-        assert_eq!(tx.send(1).await, Ok(()));
-        assert_eq!(tx.send(2).await, Ok(()));
-        let task = tokio::spawn({
-            let tx = tx.clone();
-            async move { tx.send(3).await }
-        });
-        drop(rx);
-        assert_eq!(tx.send(4).await, Err(SendError(4)));
-        assert_eq!(task.await.expect("panic"), Err(SendError(3)));
-    }
-
-    #[test]
-    fn try_send_errors() {
-        let (tx, rx) = channel::<i32>(2);
-        assert_eq!(tx.try_send(1), Ok(()));
-        assert_eq!(tx.try_send(2), Ok(()));
-        assert_eq!(tx.try_send(3), Err(TrySendError::Full(3)));
-        assert_eq!(tx.try_send(4), Err(TrySendError::Full(4)));
-        drop(rx);
-        assert_eq!(tx.try_send(5), Err(TrySendError::Disconnected(5)));
-    }
-
-    #[tokio::test]
-    async fn reserve_errors() {
-        let (tx, rx) = channel::<i32>(2);
-        tx.reserve().await.expect("reserved 1");
-        tx.reserve().await.expect("reserved 2");
-        let task = tokio::spawn({
-            let tx = tx.clone();
-            async move {
-                assert!(matches!(tx.reserve().await, Err(ReserveError)));
-            }
-        });
-        drop(rx);
-        assert!(matches!(tx.reserve().await, Err(ReserveError)));
-        task.await.expect("no panic");
-    }
-
-    #[test]
-    fn try_reserve_errors() {
-        let (tx, rx) = channel::<i32>(2);
-        let _res1 = tx.try_reserve().expect("reserved 1");
-        let _res2 = tx.try_reserve().expect("reserved 2");
-        assert!(matches!(tx.try_reserve(), Err(TryReserveError::Full)));
-        assert!(matches!(tx.try_reserve(), Err(TryReserveError::Full)));
-        drop(rx);
-        assert!(matches!(
-            tx.try_reserve(),
-            Err(TryReserveError::Disconnected)
-        ));
-    }
-
-    #[tokio::test]
-    async fn recv_future_awoken_but_unused() {
-        let (tx, rx) = channel::<i32>(1);
-        let mut recv = Box::pin(rx.recv());
-        let rx2 = rx.clone();
-        // Try receiving from rx2, but don't drop it yet.
-        tokio::select! {
-            biased;
-            _ = &mut recv => {
-                panic!("unexpected recv");
-            }
-            _ = ReadyFuture {} => {}
-        }
-        let task = tokio::spawn(async move { rx2.recv().await });
-        // Yield the current task so task above can be started.
-        tokio::time::sleep(Duration::ZERO).await;
-        tx.try_send(1).expect("sent");
-        // It would hang without the drop, since the recv would be awoken, but we'd never await for
-        // it. This is the main flaw of this design where only a single future is awoken at the
-        // time. Alternatively, we could wake all of them at once, but this would most likely
-        // result in performance degradation due to lock contention.
-        drop(recv);
-        let res = task.await.expect("no panic").expect("receivd");
-        assert_eq!(res, 1);
-    }
-
-    #[tokio::test]
-    async fn try_reserve_unused_permit_and_send() {
-        let (tx, rx) = channel::<i32>(1);
-        let permit = tx.try_reserve().expect("reserved");
-        let task = tokio::spawn({
-            let tx = tx.clone();
-            async move { tx.send(1).await }
-        });
-        drop(permit);
-        task.await.expect("no panic").expect("sent");
-        assert_eq!(rx.try_recv().expect("recv"), 1);
-    }
-
-    #[tokio::test]
-    async fn try_reserve_unused_permit_and_other_permit() {
-        let (tx, rx) = channel::<i32>(1);
-        let permit = tx.try_reserve().expect("reserved");
-        let task = tokio::spawn({
-            let tx = tx.clone();
-            async move { tx.reserve().await.expect("reserved").send(1) }
-        });
-        drop(permit);
-        task.await.expect("no panic");
-        assert_eq!(rx.try_recv().expect("recv"), 1);
-    }
-
-    #[tokio::test]
-    async fn receiver_close_all() {
-        let (tx, rx1) = channel::<i32>(3);
-        let rx2 = rx1.clone();
-        let permit1 = tx.reserve().await.unwrap();
-        let permit2 = tx.reserve().await.unwrap();
-        tx.send(1).await.unwrap();
-        rx1.close_all();
-        assert_eq!(rx1.recv().await.unwrap(), 1);
-        assert_no_recv(&rx1).await;
-        assert_no_recv(&rx2).await;
-        permit1.send(2);
-        permit2.send(3);
-        assert_eq!(rx1.recv().await.unwrap(), 2);
-        assert_eq!(rx2.try_recv().unwrap(), 3);
-        assert_eq!(rx1.recv().await, Err(RecvError));
-        assert_eq!(rx2.recv().await, Err(RecvError));
-        assert!(matches!(tx.send(3).await, Err(SendError(3))));
-    }
-
-    #[tokio::test]
-    async fn receiver_close_all_permit_drop() {
-        let (tx, rx) = channel::<i32>(3);
-        let permit = tx.reserve().await.unwrap();
-        rx.close_all();
-        assert_no_recv(&rx).await;
-        drop(permit);
-        assert_eq!(rx.recv().await, Err(RecvError));
-    }
-
-    #[tokio::test]
-    async fn reserve_owned() {
-        let (tx, rx) = channel::<usize>(4);
-        let tx = tx.reserve_owned().await.unwrap().send(1);
-        let tx = tx.reserve_owned().await.unwrap().send(2);
-        let tx = tx.try_reserve_owned().unwrap().send(3);
-        let tx = tx.try_reserve_owned().unwrap().release();
-        let tx = tx.try_reserve_owned().unwrap().send(4);
-        assert!(matches!(
-            tx.clone().try_reserve_owned(),
-            Err(TrySendError::Full(_))
-        ));
-        for i in 1..=4 {
-            assert_eq!(rx.try_recv().unwrap(), i);
-        }
-        drop(rx);
-        assert!(matches!(
-            tx.clone().reserve_owned().await,
-            Err(ReserveError)
-        ));
-        assert!(matches!(
-            tx.try_reserve_owned(),
-            Err(TrySendError::Disconnected(_))
-        ));
-    }
-
-    #[tokio::test]
-    async fn reserve_many() {
-        let (tx, rx) = channel::<usize>(10);
-        let p1 = tx.reserve_many(5).await.unwrap();
-        let p2 = tx.try_reserve_many(5).unwrap();
-        assert!(matches!(tx.try_send(11), Err(TrySendError::Full(11))));
-        for (i, p) in p1.enumerate() {
-            p.send(i);
-        }
-        for (i, p) in p2.enumerate() {
-            p.send(i + 5);
-        }
-        for i in 0..10 {
-            assert_eq!(rx.try_recv().unwrap(), i);
-        }
-    }
-
-    #[tokio::test]
-    async fn reserve_many_drop() {
-        let (tx, _rx) = channel::<usize>(2);
-        let it = tx.reserve_many(2).await.unwrap();
-        drop(it);
-        tx.try_send(1).unwrap();
-        tx.try_send(2).unwrap();
-        assert!(matches!(tx.try_send(3), Err(TrySendError::Full(3))));
-    }
-
-    #[tokio::test]
-    async fn reserve_many_drop_halfway() {
-        let (tx, _rx) = channel::<usize>(4);
-        let mut it = tx.reserve_many(4).await.unwrap();
-        it.next().unwrap().send(1);
-        it.next().unwrap().send(2);
-        drop(it);
-        tx.try_send(3).unwrap();
-        tx.try_send(4).unwrap();
-        assert!(matches!(tx.try_send(5), Err(TrySendError::Full(5))));
-    }
-
-    async fn assert_no_recv<T>(rx: &Receiver<T>)
-    where
-        T: std::fmt::Debug + Send + Sync + 'static,
-    {
-        tokio::select! {
-            result = rx.recv() => {
-                panic!("unexpected recv: {result:?}");
-            },
-            _ = tokio::time::sleep(std::time::Duration::ZERO) => {},
-        }
-    }
-
-    struct ReadyFuture {}
-
-    impl Future for ReadyFuture {
-        type Output = ();
-
-        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-            Poll::Ready(())
-        }
-    }
-}
+///! A multi-producer, multi-consumer async channel with reservations.
+///!
+///! Example usage:
+///!
+///! ```rust
+///! tokio_test::block_on(async {
+///!     let (tx1, rx1) = mpmc_async::channel(2);
+///!
+///!     let task = tokio::spawn(async move {
+///!       let rx2 = rx1.clone();
+///!       assert_eq!(rx1.recv().await.unwrap(), 1);
+///!       assert_eq!(rx2.recv().await.unwrap(), 2);
+///!     });
+///!
+///!     let tx2 = tx1.clone();
+///!     let permit = tx1.reserve().await.unwrap();
+///!     tx2.send(1).await.unwrap();
+///!     permit.send(2);
+///!
+///!     task.await.unwrap();
+///! });
+///! ```
+///!
+///! A more complex example with multiple sender and receiver tasks:
+///!
+///! ```rust
+///! use std::collections::BTreeSet;
+///! use std::ops::DerefMut;
+///! use std::sync::{Arc, Mutex};
+///!
+///! tokio_test::block_on(async {
+///!     let (tx, rx) = mpmc_async::channel(1);
+///!
+///!     let num_workers = 10;
+///!     let count = 10;
+///!     let mut tasks = Vec::with_capacity(num_workers);
+///!
+///!     for i in 0..num_workers {
+///!         let mut tx = tx.clone();
+///!         let task = tokio::spawn(async move {
+///!             for j in 0..count {
+///!                 let val = i * count + j;
+///!                 tx.reserve().await.expect("no error").send(val);
+///!             }
+///!         });
+///!         tasks.push(task);
+///!     }
+///!
+///!     let total = count * num_workers;
+///!     let values = Arc::new(Mutex::new(BTreeSet::new()));
+///!
+///!     for _ in 0..num_workers {
+///!         let values = values.clone();
+///!         let rx = rx.clone();
+///!         let task = tokio::spawn(async move {
+///!             for _ in 0..count {
+///!                 let val = rx.recv().await.expect("Failed to recv");
+///!                 values.lock().unwrap().insert(val);
+///!             }
+///!         });
+///!         tasks.push(task);
+///!     }
+///!
+///!     for task in tasks {
+///!         task.await.expect("failed to join task");
+///!     }
+///!
+///!     let exp = (0..total).collect::<Vec<_>>();
+///!     let got = std::mem::take(values.lock().unwrap().deref_mut())
+///!         .into_iter()
+///!         .collect::<Vec<_>>();
+///!     assert_eq!(exp, got);
+///! });
+///! ```
+pub mod linked_list;
+pub mod queue;
+
+// use std::collections::{BTreeMap, VecDeque};
+//use std::fmt::Display;
+//use std::ops::DerefMut;
+//use std::pin::Pin;
+//use std::sync::{Arc, Mutex};
+//use std::task::{Context, Poll, Waker};
+
+//use std::future::Future;
+
+//use self::linked_list::{LinkedList, NodeRef};
+
+///// Occurs when all receivers have been dropped.
+//#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+//pub struct SendError<T>(pub T);
+
+//impl<T> Display for SendError<T> {
+//    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//        f.write_str("Send failed: disconnected")
+//    }
+//}
+
+///// TrySendError occurs when the channel is empty or all receivers have been dropped.
+//#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+//pub enum TrySendError<T> {
+//    /// Channel full
+//    Full(T),
+//    /// Disconnected
+//    Disconnected(T),
+//}
+
+//impl<T> Display for TrySendError<T> {
+//    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//        match self {
+//            TrySendError::Full(_) => f.write_str("Try send failed: full"),
+//            TrySendError::Disconnected(_) => f.write_str("Try send failed: disconnected"),
+//        }
+//    }
+//}
+
+///// Occurs when all receivers have been dropped.
+//#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+//pub struct ReserveError;
+
+//impl Display for ReserveError {
+//    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//        f.write_str("Reserve failed: disconnected")
+//    }
+//}
+
+///// Occurs when the channel is full, or all receivers have been dropped.
+//#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+//pub enum TryReserveError {
+//    /// Channel full
+//    Full,
+//    /// Disconnected
+//    Disconnected,
+//}
+
+//impl TryReserveError {
+//    fn into_try_send_error<T>(self, value: T) -> TrySendError<T> {
+//        match self {
+//            TryReserveError::Full => TrySendError::Full(value),
+//            TryReserveError::Disconnected => TrySendError::Disconnected(value),
+//        }
+//    }
+//}
+
+//impl Display for TryReserveError {
+//    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//        match self {
+//            TryReserveError::Full => f.write_str("Try send failed: full"),
+//            TryReserveError::Disconnected => f.write_str("Try send failed: disconnected"),
+//        }
+//    }
+//}
+
+///// Occurs when all senders have been dropped.
+//#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+//pub struct RecvError;
+
+//impl Display for RecvError {
+//    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//        f.write_str("Recv failed: disconnected")
+//    }
+//}
+
+///// Occurs when channel is empty or all senders have been dropped.
+//#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+//pub enum TryRecvError {
+//    /// Channel is empty
+//    Empty,
+//    /// Disconnected
+//    Disconnected,
+//}
+
+//impl Display for TryRecvError {
+//    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//        match self {
+//            TryRecvError::Empty => f.write_str("Try recv failed: empty"),
+//            TryRecvError::Disconnected => f.write_str("Try recv failed: disconnected"),
+//        }
+//    }
+//}
+
+///// Creates a new bounded channel. When `cap` is 0 it will be increased to 1.
+//pub fn channel<T>(mut cap: usize) -> (Sender<T>, Receiver<T>)
+//where
+//    T: Send + Sync + 'static,
+//{
+//    if cap == 0 {
+//        cap = 1
+//    }
+
+//    let state = State {
+//        inner: Arc::new(Mutex::new(InnerState {
+//            buffer: VecDeque::with_capacity(cap),
+//            reserved_count: 0,
+//            receivers_count: 0,
+//            senders_count: 0,
+//            waiting_send_futures: LinkedList::new(),
+//            waiting_recv_futures: LinkedList::new(),
+//            disconnected: false,
+//        })),
+//    };
+
+//    (state.new_sender(), state.new_receiver())
+//}
+
+///// Receives messages sent by [Sender].
+//pub struct Receiver<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    state: State<T>,
+//}
+
+///// Cloning creates new a instance with the shared state  and increases the internal reference
+///// counter. It is guaranteed that a single message will be distributed to exacly one receiver
+///// future awaited after calling `recv()`.
+//impl<T> Clone for Receiver<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn clone(&self) -> Self {
+//        self.state.new_receiver()
+//    }
+//}
+
+//impl<T> Receiver<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn new(state: State<T>) -> Self {
+//        Self { state }
+//    }
+
+//    /// Disconnects all receivers from senders. The receivers will still receive all buffered
+//    /// or reserved messages before returning an error, allowing a graceful teardown.
+//    pub fn close_all(&self) {
+//        self.state.close_all_receivers();
+//    }
+
+//    /// Waits until there's a message to be read and returns. Returns an error when there are no
+//    /// more messages in the queue and all [Sender]s have been dropped.
+//    pub async fn recv(&self) -> Result<T, RecvError> {
+//        let recv = RecvFuture::new(self);
+
+//        recv.await
+//    }
+
+//    /// Checks if there's a message to be read and returns immediately. Returns an error when the
+//    /// channel is disconnected or empty.
+//    pub fn try_recv(&self) -> Result<T, TryRecvError> {
+//        let mut state = self.state.inner_mut();
+
+//        if let Some(value) = state.buffer.pop_front() {
+//            Ok(value)
+//        } else if state.disconnected && state.reserved_count == 0 {
+//            Err(TryRecvError::Disconnected)
+//        } else {
+//            Err(TryRecvError::Empty)
+//        }
+//    }
+
+//    pub async fn recv_many(&self, vec: &mut Vec<T>, count: usize) -> Result<usize, RecvError> {
+//        let recv = RecvManyFuture::new(self.state.next_waker_id(), self, vec, count);
+//        recv.await
+//    }
+
+//    pub fn try_recv_many(&self, vec: &mut Vec<T>, count: usize) -> Result<usize, TryRecvError> {
+//        let mut state = self.state.inner_mut();
+
+//        if let Some(value) = state.buffer.pop_front() {
+//            let mut num_received = 1;
+//            vec.push(value);
+
+//            for _ in 1..count {
+//                match state.buffer.pop_front() {
+//                    Some(value) => {
+//                        vec.push(value);
+//                        num_received += 1;
+//                    }
+//                    None => break,
+//                }
+//            }
+
+//            Ok(num_received)
+//        } else if state.disconnected && state.reserved_count == 0 {
+//            Err(TryRecvError::Disconnected)
+//        } else {
+//            Err(TryRecvError::Empty)
+//        }
+//    }
+//}
+
+///// The last reciever that's dropped will mark the channel as disconnected.
+//impl<T> Drop for Receiver<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn drop(&mut self) {
+//        self.state.drop_receiver();
+//    }
+//}
+
+///// Producers messages to be read by [Receiver]s.
+//#[derive(Debug)]
+//pub struct Sender<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    state: State<T>,
+//}
+
+///// Cloning creates new a instance with the shared state  and increases the internal reference
+///// counter.
+//impl<T> Clone for Sender<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn clone(&self) -> Self {
+//        self.state.new_sender()
+//    }
+//}
+
+//impl<T> Sender<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn new(state: State<T>) -> Sender<T> {
+//        Self { state }
+//    }
+
+//    /// Waits until the value is sent or returns an when all receivers have been dropped.
+//    pub async fn send(&self, value: T) -> Result<(), SendError<T>> {
+//        match self.reserve().await {
+//            Ok(permit) => {
+//                permit.send(value);
+//                Ok(())
+//            }
+//            Err(err) => Err(err.into_try_send_error(value)),
+//        }
+//    }
+
+//    /// Sends without blocking or returns an when all receivers have been dropped.
+//    pub fn try_send(&self, value: T) -> Result<(), TrySendError<T>> {
+//        let mut state = self.state.inner_mut();
+
+//        if state.disconnected {
+//            return Err(TrySendError::Disconnected(value));
+//        }
+
+//        if state.has_room_for(1) {
+//            if let Some(waker) = state.send_and_get_waker(value) {
+//                drop(state);
+//                waker.wake();
+//            }
+//            Ok(())
+//        } else {
+//            Err(TrySendError::Full(value))
+//        }
+//    }
+
+//    /// Waits until a permit is reserved or returns an when all receivers have been dropped.
+//    pub async fn reserve(&self) -> Result<Permit<'_, T>, ReserveError> {
+//        ReserveFuture::new(self.state.next_waker_id(), &self.state, 1).await?;
+//        Ok(Permit::new(self))
+//    }
+
+//    /// Reserves a permit or returns an when all receivers have been dropped.
+//    pub fn try_reserve(&self) -> Result<Permit<'_, T>, TryReserveError> {
+//        let mut state = self.state.inner_mut();
+
+//        if state.disconnected {
+//            return Err(TryReserveError::Disconnected);
+//        }
+
+//        if state.has_room_for(1) {
+//            state.reserved_count += 1;
+//            Ok(Permit::new(self))
+//        } else {
+//            Err(TryReserveError::Full)
+//        }
+//    }
+
+//    /// Waits until multiple Permits in the queue are reserved.
+//    pub async fn reserve_many(&self, count: usize) -> Result<PermitIterator<'_, T>, ReserveError> {
+//        ReserveFuture::new(self.state.next_waker_id(), &self.state, count).await?;
+//        Ok(PermitIterator::new(self, count))
+//    }
+
+//    /// Reserves multiple Permits in the queue, or errors out when there's no room.
+//    pub fn try_reserve_many(&self, count: usize) -> Result<PermitIterator<'_, T>, TryReserveError> {
+//        let mut state = self.state.inner_mut();
+
+//        if state.disconnected {
+//            return Err(TryReserveError::Disconnected);
+//        }
+
+//        if state.has_room_for(count) {
+//            state.reserved_count += count;
+//            Ok(PermitIterator::new(self, count))
+//        } else {
+//            Err(TryReserveError::Full)
+//        }
+//    }
+
+//    /// Like [Sender::reserve], but takes ownership of `Sender` until sending is done.
+//    pub async fn reserve_owned(self) -> Result<OwnedPermit<T>, ReserveError> {
+//        ReserveFuture::new(self.state.next_waker_id(), &self.state, 1).await?;
+//        Ok(OwnedPermit::new(self))
+//    }
+
+//    /// Reserves a permit or returns an when all receivers have been dropped.
+//    pub fn try_reserve_owned(self) -> Result<OwnedPermit<T>, TrySendError<Self>> {
+//        let mut state = self.state.inner_mut();
+
+//        if state.disconnected {
+//            drop(state);
+//            return Err(TrySendError::Disconnected(self));
+//        }
+
+//        if state.has_room_for(1) {
+//            state.reserved_count += 1;
+//            drop(state);
+//            Ok(OwnedPermit::new(self))
+//        } else {
+//            drop(state);
+//            Err(TrySendError::Full(self))
+//        }
+//    }
+//}
+
+///// The last sender that's dropped will mark the channel as disconnected.
+//impl<T> Drop for Sender<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn drop(&mut self) {
+//        self.state.drop_sender();
+//    }
+//}
+
+//#[derive(Debug)]
+//struct State<T> {
+//    inner: Arc<Mutex<InnerState<T>>>,
+//}
+
+//impl<T> Clone for State<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn clone(&self) -> Self {
+//        Self {
+//            inner: Arc::clone(&self.inner),
+//        }
+//    }
+//}
+
+//impl<T> State<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn inner_mut(&self) -> impl DerefMut<Target = InnerState<T>> + '_ {
+//        self.inner.lock().unwrap()
+//    }
+
+//    fn next_waker_id(&self) -> WakerId {
+//        self.inner_mut().next_waker_id()
+//    }
+
+//    fn new_sender(&self) -> Sender<T> {
+//        self.inner_mut().senders_count += 1;
+//        Sender::new(self.clone())
+//    }
+
+//    fn new_receiver(&self) -> Receiver<T> {
+//        self.inner_mut().receivers_count += 1;
+//        Receiver::new(self.clone())
+//    }
+
+//    fn wake_all(wakers: Option<impl Iterator<Item = Waker>>) {
+//        if let Some(wakers) = wakers {
+//            for waker in wakers {
+//                waker.wake()
+//            }
+//        }
+//    }
+
+//    fn close_all_receivers(&self) {
+//        let (send_wakers, recv_wakers) = {
+//            let mut inner = self.inner_mut();
+//            let send_wakers = inner.mark_disconnected_and_take_send_futures();
+//            // Keep receivers alive in case there are any active Permits.
+//            let recv_wakers = (inner.reserved_count == 0)
+//                .then(|| inner.mark_disconnected_and_take_recv_futures());
+
+//            (send_wakers, recv_wakers)
+//        };
+
+//        Self::wake_all(Some(send_wakers));
+//        Self::wake_all(recv_wakers);
+//    }
+
+//    fn drop_sender(&self) {
+//        let wakers = {
+//            let mut inner = self.inner_mut();
+//            inner.senders_count -= 1;
+
+//            (inner.senders_count == 0).then(|| inner.mark_disconnected_and_take_recv_futures())
+//        };
+
+//        Self::wake_all(wakers);
+//    }
+
+//    fn drop_receiver(&self) {
+//        let wakers = {
+//            let mut inner = self.inner_mut();
+//            inner.receivers_count -= 1;
+
+//            (inner.receivers_count == 0).then(|| inner.mark_disconnected_and_take_send_futures())
+//        };
+
+//        Self::wake_all(wakers);
+//    }
+
+//    fn drop_permit(&self, has_sent: bool) {
+//        let waker = {
+//            let mut inner = self.inner_mut();
+//            inner.reserved_count -= 1;
+
+//            // When the permit was not used for sending, it means a spot was freed, so we can notify
+//            // one of the senders to proceed.
+//            (!has_sent)
+//                .then(|| inner.waiting_send_futures.pop_first())
+//                .flatten()
+//        };
+
+//        if let Some((_, waker)) = waker {
+//            waker.wake();
+//        }
+//    }
+
+//    fn drop_send_future(&self, fut: Option<NodeRef<SendWaiting>>) {
+//        let waker = {
+//            let mut inner = self.inner_mut();
+
+//            if let Some(fut) = fut {
+//                inner.waiting_send_futures.remove(fut);
+//                inner.reserved_count -= fut.count
+//            }
+
+//            // If there's room for the next sender in the queue, wake it.
+//            match inner.waiting_send_futures.head() {
+//                Some(next) => inner.has_room_for(next.count).then(|| next.waker.clone()),
+//                None => None,
+//            }
+//        };
+
+//        if let Some(waker) = waker {
+//            waker.wake();
+//        }
+//    }
+
+//    fn drop_recv_future(&self, id: &WakerId, has_received: bool) {
+//        let waker = {
+//            let mut inner = self.inner_mut();
+//            let was_awoken = inner.waiting_recv_futures.remove(id).is_none();
+
+//            // Wake another receiver in case this one has been awoken, but it was dropped before it
+//            // managed to receive anything.
+//            if was_awoken {
+//                if has_received {
+//                    // If we have received, it means a spot was freed in the internal buffer, so wake
+//                    // one sender.
+//                    inner.take_one_send_future_waker()
+//                } else {
+//                    // If we have not received, it means another RecvFuture might take over.
+//                    inner.take_one_recv_future_waker()
+//                }
+//            } else {
+//                None
+//            }
+//        };
+
+//        if let Some(waker) = waker {
+//            waker.wake();
+//        }
+//    }
+//}
+
+//struct SendWaiting {
+//    count: usize,
+//    waker: Waker,
+//}
+
+//impl SendWaiting {
+//    fn new(count: usize, waker: Waker) -> Self {
+//        Self {
+//            count,
+//            waker
+//        }
+//    }
+//}
+
+//// TODO we need acustom impl of a LinkedList to be able to add/remove wakers, instead of using
+//// WakerId.
+////
+//// Moreover, currently reservations are just a counter, they don't actually take the
+//// spot in the buffer, so in the case of a single consumer the result will be
+//// re-ordered. We could keep an enum like this:
+////
+//// ```
+//// enum Spot<T> {
+////   Value(T),
+////   Reserved,
+//// }
+//// ```
+////
+//// in the buffer so that we know we need to wait for the reservations.
+//struct InnerState<T> {
+//    /// Next message ready to be received.
+//    next: Option<T>,
+//    /// Buffered messages, capacity is fixed.
+//    buffer: VecDeque<T>,
+//    /// All reservations.
+//    reservations: LinkedList<Message<T>>,
+//    cap: usize,
+//    len: usize,
+//    /// Total of created receivers.
+//    receivers_count: usize,
+//    /// Total of created senders.
+//    senders_count: usize,
+//    /// Senders waiting to send.
+//    waiting_send_futures: LinkedList<SendWaiting>,
+//    /// Receivers waiting to receive.
+//    waiting_recv_futures: LinkedList<Waker>,
+//    /// False by default, true when all senders or all receivers are dropped.
+//    disconnected: bool,
+//}
+
+//impl<T> InnerState<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn has_room_for(&self, required_num_items: usize) -> bool {
+//        let space = self.buffer.capacity() - self.buffer.len();
+//        space >= required_num_items
+//    }
+
+//    #[must_use]
+//    fn send_and_get_receiver_waker(&mut self, value: T, waker: NodeRef<SendWaiting>) -> Option<&Waker> {
+//        self.buffer.push_back(value);
+//        self.waiting_send_futures.remove(waker);
+//        self.waiting_recv_futures.head()
+//    }
+
+//    fn mark_disconnected_and_take_send_futures(&mut self) -> impl Iterator<Item = Waker> {
+//        self.disconnected = true;
+//        Self::take_all_wakers(&mut self.waiting_send_futures).into_values()
+//    }
+
+//    fn mark_disconnected_and_take_recv_futures(&mut self) -> impl Iterator<Item = Waker> {
+//        self.disconnected = true;
+//        Self::take_all_wakers(&mut self.waiting_recv_futures).into_values()
+//    }
+
+//    #[must_use]
+//    fn take_one_send_future_waker(&mut self) -> Option<Waker> {
+//        if self.has_room_for(1) {
+//            Self::take_one_waker(&mut self.waiting_send_futures)
+//        } else {
+//            None
+//        }
+//    }
+
+//    #[must_use]
+//    fn take_one_recv_future_waker(&mut self) -> Option<Waker> {
+//        if !self.buffer.is_empty() {
+//            Self::take_one_waker(&mut self.waiting_recv_futures)
+//        } else {
+//            None
+//        }
+//    }
+
+//    #[must_use]
+//    fn take_one_waker(map: &mut BTreeMap<WakerId, Waker>) -> Option<Waker> {
+//        map.pop_first().map(|(_, waker)| waker)
+//    }
+
+//    fn take_all_wakers(map: &mut BTreeMap<WakerId, Waker>) -> BTreeMap<WakerId, Waker> {
+//        std::mem::take(map)
+//    }
+//}
+
+//enum Message<T> {
+//    Value(T),
+//    Reserved,
+//}
+
+//type WakerId = usize;
+
+//// struct SendFuture<'a, T>
+//// where
+////     T: Send + Sync + 'static,
+//// {
+////     sender: &'a Sender<T>,
+////     position: Option<NodeRef<Waker>>,
+////     value: Option<T>,
+//// }
+
+//// impl<'a, T> SendFuture<'a, T>
+//// where
+////     T: Send + Sync + 'static,
+//// {
+////     fn new(sender: &'a Sender<T>, value: T) -> Self {
+////         Self {
+////             sender,
+////             position: None,
+////             value: Some(value),
+////         }
+////     }
+//// }
+
+//// impl<'a, T> Unpin for SendFuture<'a, T> where T: Send + Sync + 'static {}
+
+//// impl<'a, T> Future for SendFuture<'a, T>
+//// where
+////     T: Send + Sync + 'static,
+//// {
+////     type Output = Result<(), SendError<T>>;
+
+////     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+////         // Already sent this value.
+////         if self.value.is_none() {
+////             return Poll::Ready(Ok(()));
+////         }
+
+////         let this = self.deref_mut();
+////         let mut state = this.sender.state.inner_mut();
+
+////         if state.disconnected {
+////             Poll::Ready(Err(SendError(this.value.take().expect("some value"))))
+////         } else if state.has_room_for(1) {
+////             if let Some(waker) = state.send_get_receiver_waker(
+////                 this.value.take().expect("some value"),
+////                 this.position.take().expect("position"),
+////             ) {
+////                 drop(state);
+////                 waker.wake();
+////             }
+////             Poll::Ready(Ok(()))
+////         } else if self.position.is_none() {
+////             let position = state
+////                 .waiting_send_futures
+////                 .push(cx.waker().clone());
+////             self.position = Some(position);
+////             Poll::Pending
+////         } else {
+////             Poll::Pending
+////         }
+////     }
+//// }
+
+//// impl<'a, T> Drop for SendFuture<'a, T>
+//// where
+////     T: Send + Sync + 'static,
+//// {
+////     fn drop(&mut self) {
+////         let has_sent = self.value.is_none();
+////         self.sender.state.drop_send_future(self.position.take());
+////     }
+//// }
+
+///// Permit holds a spot in the internal buffer so the message can be sent without awaiting.
+//pub struct Permit<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    sender: &'a Sender<T>,
+//    node_ref: NodeRef<Message<T>>,
+//    has_sent: bool,
+//}
+
+//impl<'a, T> Permit<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn new(sender: &'a Sender<T>) -> Self {
+//        Self {
+//            sender,
+//            has_sent: false,
+//        }
+//    }
+
+//    /// Writes a message to the internal buffer.
+//    pub fn send(mut self, value: T) {
+//        if let Some(waker) = self.sender.state.inner_mut().send_and_get_waker(value) {
+//            waker.wake();
+//        }
+//        self.has_sent = true;
+//        drop(self)
+//    }
+//}
+
+//impl<'a, T> Drop for Permit<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn drop(&mut self) {
+//        self.sender.state.drop_permit(self.has_sent);
+//    }
+//}
+
+//pub struct PermitIterator<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    sender: &'a Sender<T>,
+//    count: usize,
+//}
+
+//impl<'a, T> PermitIterator<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    pub fn new(sender: &'a Sender<T>, count: usize) -> Self {
+//        Self { sender, count }
+//    }
+//}
+
+//impl<'a, T> Iterator for PermitIterator<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    type Item = Permit<'a, T>;
+
+//    fn next(&mut self) -> Option<Self::Item> {
+//        if self.count == 0 {
+//            None
+//        } else {
+//            self.count -= 1;
+//            Some(Permit::new(self.sender))
+//        }
+//    }
+//}
+
+//impl<'a, T> Drop for PermitIterator<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn drop(&mut self) {
+//        for _ in 0..self.count {
+//            self.sender.state.drop_permit(false);
+//        }
+//    }
+//}
+
+//pub struct OwnedPermit<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    sender: Option<Sender<T>>,
+//}
+
+//impl<T> OwnedPermit<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn new(sender: Sender<T>) -> Self {
+//        Self {
+//            sender: Some(sender),
+//        }
+//    }
+
+//    /// Writes a message to the internal buffer.
+//    pub fn send(mut self, value: T) -> Sender<T> {
+//        let sender = self
+//            .sender
+//            .take()
+//            .expect("sender is only taken when permit is consumed");
+
+//        if let Some(waker) = sender.state.inner_mut().send_and_get_waker(value) {
+//            waker.wake();
+//        }
+
+//        sender.state.drop_permit(true);
+
+//        sender
+//    }
+
+//    pub fn release(mut self) -> Sender<T> {
+//        let sender = self
+//            .sender
+//            .take()
+//            .expect("sender is only taken when permit is consumed");
+
+//        sender.state.drop_permit(false);
+
+//        sender
+//    }
+//}
+
+//impl<T> Drop for OwnedPermit<T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn drop(&mut self) {
+//        // if we haven't called send or release:
+//        if let Some(sender) = &self.sender {
+//            sender.state.drop_permit(false);
+//        }
+//    }
+//}
+
+//struct ReserveFuture<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    id: WakerId,
+//    waiting: Option<NodeRef<SendWaiting>>,
+//    state: &'a State<T>,
+//    count: usize,
+//}
+
+//impl<'a, T> ReserveFuture<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn new(id: WakerId, state: &'a State<T>, count: usize) -> Self {
+//        Self {
+//            id,
+//            state,
+//            count,
+//            has_reserved: false,
+//        }
+//    }
+//}
+
+//impl<'a, T> Future for ReserveFuture<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    type Output = Result<(), ReserveError>;
+
+//    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+//        if self.has_reserved {
+//            panic!("ReservedFuture polled after ready");
+//        }
+
+//        let this = self.deref_mut();
+//        let mut state = this.state.inner_mut();
+//        if state.disconnected {
+//            Poll::Ready(Err(ReserveError))
+//        } else if state.has_room_for(this.count) {
+//            state.buffer.push(Message::Reserved);
+//            state.reserved_count += this.count;
+//            Poll::Ready(Ok(()))
+//        } else if self.waiting.is_none() {
+//            let waiting = state
+//                .waiting_send_futures
+//                .push(SendWaiting::new(self.count, cx.waker().clone()));
+//            self.waiting = Some(waiting);
+//            Poll::Pending
+//        } else {
+//            Poll::Pending
+//        }
+//    }
+//}
+
+//struct RecvFuture<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    receiver: &'a Receiver<T>,
+//    waker_ref: NodeRef<Waker>,
+//    has_received: bool,
+//}
+
+//impl<'a, T> RecvFuture<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn new(receiver: &'a Receiver<T>) -> Self {
+//        Self {
+//            receiver,
+//            has_received: false,
+//        }
+//    }
+//}
+
+//impl<'a, T> Unpin for RecvFuture<'a, T> where T: Send + Sync + 'static {}
+
+//impl<'a, T> Future for RecvFuture<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    type Output = Result<T, RecvError>;
+
+//    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+//        let this = self.deref_mut();
+//        let mut state = this.receiver.state.inner_mut();
+//        let value = state.buffer.pop_front();
+
+//        match value {
+//            Some(value) => {
+//                this.has_received = true;
+//                Poll::Ready(Ok(value))
+//            }
+//            None => {
+//                if state.disconnected && state.reserved_count == 0 {
+//                    Poll::Ready(Err(RecvError))
+//                } else {
+//                    state.waiting_recv_futures.push(cx.waker().clone());
+//                    if let Some(waker) = state.take_one_send_future_waker() {
+//                        drop(state);
+//                        waker.wake();
+//                    }
+//                    Poll::Pending
+//                }
+//            }
+//        }
+//    }
+//}
+
+//impl<'a, T> Drop for RecvFuture<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn drop(&mut self) {
+//        self.receiver
+//            .state
+//            .drop_recv_future(&self.id, self.has_received);
+//    }
+//}
+
+//struct RecvManyFuture<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    id: WakerId,
+//    receiver: &'a Receiver<T>,
+//    vec: &'a mut Vec<T>,
+//    count: usize,
+//    has_received: bool,
+//}
+
+//impl<'a, T> RecvManyFuture<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn new(id: WakerId, receiver: &'a Receiver<T>, vec: &'a mut Vec<T>, count: usize) -> Self {
+//        Self {
+//            id,
+//            receiver,
+//            vec,
+//            count,
+//            has_received: false,
+//        }
+//    }
+//}
+
+//impl<'a, T> Unpin for RecvManyFuture<'a, T> where T: Send + Sync + 'static {}
+
+//impl<'a, T> Future for RecvManyFuture<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    type Output = Result<usize, RecvError>;
+
+//    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+//        let this = self.deref_mut();
+//        let mut state = this.receiver.state.inner_mut();
+
+//        let value = state.buffer.pop_front();
+
+//        match value {
+//            Some(value) => {
+//                let mut num_received = 1;
+//                this.vec.push(value);
+
+//                for _ in 1..this.count {
+//                    match state.buffer.pop_front() {
+//                        Some(value) => {
+//                            this.vec.push(value);
+//                            num_received += 1;
+//                        }
+//                        None => break,
+//                    }
+//                }
+
+//                this.has_received = true;
+//                Poll::Ready(Ok(num_received))
+//            }
+//            None => {
+//                if state.disconnected && state.reserved_count == 0 {
+//                    Poll::Ready(Err(RecvError))
+//                } else {
+//                    state
+//                        .waiting_recv_futures
+//                        .insert(this.id, cx.waker().clone());
+//                    if let Some(waker) = state.take_one_send_future_waker() {
+//                        drop(state);
+//                        waker.wake();
+//                    }
+//                    Poll::Pending
+//                }
+//            }
+//        }
+//    }
+//}
+
+//impl<'a, T> Drop for RecvManyFuture<'a, T>
+//where
+//    T: Send + Sync + 'static,
+//{
+//    fn drop(&mut self) {
+//        self.receiver
+//            .state
+//            .drop_recv_future(&self.id, self.has_received);
+//    }
+//}
+
+//#[cfg(test)]
+//mod testing {
+//    use std::collections::BTreeSet;
+//    use std::time::Duration;
+
+//    use super::*;
+
+//    #[tokio::test]
+//    async fn send_receive() {
+//        let (tx, rx) = channel(1);
+//        tx.send(1).await.expect("no error");
+//        let res = rx.recv().await.expect("no error");
+//        assert_eq!(res, 1);
+//    }
+
+//    #[tokio::test]
+//    async fn mpsc() {
+//        let (tx, rx) = channel(1);
+
+//        let num_workers = 10;
+//        let count = 10;
+//        let mut tasks = Vec::with_capacity(num_workers);
+
+//        for i in 0..num_workers {
+//            let tx = tx.clone();
+//            let task = tokio::spawn(async move {
+//                for j in 0..count {
+//                    let val = i * count + j;
+//                    tx.send(val).await.expect("Failed to send");
+//                }
+//            });
+//            tasks.push(task);
+//        }
+
+//        let total = count * num_workers;
+//        let mut values = BTreeSet::new();
+
+//        for _ in 0..total {
+//            let value = rx.recv().await.expect("no error");
+//            values.insert(value);
+//        }
+
+//        let exp = (0..total).collect::<Vec<_>>();
+//        let got = values.into_iter().collect::<Vec<_>>();
+//        assert_eq!(exp, got);
+
+//        for task in tasks {
+//            task.await.expect("failed to join task");
+//        }
+//    }
+
+//    async fn run_tasks<F, Fut>(send: F)
+//    where
+//        Fut: Future<Output = Sender<usize>> + Send,
+//        F: Send + Sync + 'static + Copy,
+//        F: Fn(Sender<usize>, usize) -> Fut,
+//    {
+//        let (tx, rx) = channel(1);
+
+//        let num_workers = 10;
+//        let count = 10;
+//        let mut tasks = Vec::with_capacity(num_workers);
+
+//        for i in 0..num_workers {
+//            let mut tx = tx.clone();
+//            let task = tokio::spawn(async move {
+//                for j in 0..count {
+//                    let val = i * count + j;
+//                    tx = send(tx, val).await;
+//                }
+//            });
+//            tasks.push(task);
+//        }
+
+//        let total = count * num_workers;
+//        let values = Arc::new(Mutex::new(BTreeSet::new()));
+
+//        for _ in 0..num_workers {
+//            let values = values.clone();
+//            let rx = rx.clone();
+//            let task = tokio::spawn(async move {
+//                for _ in 0..count {
+//                    let val = rx.recv().await.expect("Failed to recv");
+//                    values.lock().unwrap().insert(val);
+//                }
+//            });
+//            tasks.push(task);
+//        }
+
+//        for task in tasks {
+//            task.await.expect("failed to join task");
+//        }
+
+//        let exp = (0..total).collect::<Vec<_>>();
+//        let got = std::mem::take(values.lock().unwrap().deref_mut())
+//            .into_iter()
+//            .collect::<Vec<_>>();
+//        assert_eq!(exp, got);
+//    }
+
+//    #[tokio::test]
+//    async fn mpmc_multiple_tasks() {
+//        run_tasks(|tx, value| async move {
+//            tx.send(value).await.expect("Failed to send");
+//            tx
+//        })
+//        .await;
+//    }
+
+//    #[tokio::test]
+//    async fn mpmc_reserve() {
+//        run_tasks(|tx, value| async move {
+//            tx.reserve().await.expect("Failed to send").send(value);
+//            tx
+//        })
+//        .await;
+//    }
+
+//    #[tokio::test]
+//    async fn mpmc_try_reserve() {
+//        run_tasks(|tx, value| async move {
+//            loop {
+//                match tx.try_reserve() {
+//                    Ok(permit) => {
+//                        permit.send(value);
+//                    }
+//                    Err(_err) => {
+//                        tokio::time::sleep(Duration::ZERO).await;
+//                        continue;
+//                    }
+//                };
+
+//                return tx;
+//            }
+//        })
+//        .await;
+//    }
+
+//    #[tokio::test]
+//    async fn send_errors() {
+//        let (tx, rx) = channel::<i32>(2);
+//        assert_eq!(tx.send(1).await, Ok(()));
+//        assert_eq!(tx.send(2).await, Ok(()));
+//        let task = tokio::spawn({
+//            let tx = tx.clone();
+//            async move { tx.send(3).await }
+//        });
+//        drop(rx);
+//        assert_eq!(tx.send(4).await, Err(SendError(4)));
+//        assert_eq!(task.await.expect("panic"), Err(SendError(3)));
+//    }
+
+//    #[test]
+//    fn try_send_errors() {
+//        let (tx, rx) = channel::<i32>(2);
+//        assert_eq!(tx.try_send(1), Ok(()));
+//        assert_eq!(tx.try_send(2), Ok(()));
+//        assert_eq!(tx.try_send(3), Err(TrySendError::Full(3)));
+//        assert_eq!(tx.try_send(4), Err(TrySendError::Full(4)));
+//        drop(rx);
+//        assert_eq!(tx.try_send(5), Err(TrySendError::Disconnected(5)));
+//    }
+
+//    #[tokio::test]
+//    async fn reserve_errors() {
+//        let (tx, rx) = channel::<i32>(2);
+//        tx.reserve().await.expect("reserved 1");
+//        tx.reserve().await.expect("reserved 2");
+//        let task = tokio::spawn({
+//            let tx = tx.clone();
+//            async move {
+//                assert!(matches!(tx.reserve().await, Err(ReserveError)));
+//            }
+//        });
+//        drop(rx);
+//        assert!(matches!(tx.reserve().await, Err(ReserveError)));
+//        task.await.expect("no panic");
+//    }
+
+//    #[test]
+//    fn try_reserve_errors() {
+//        let (tx, rx) = channel::<i32>(2);
+//        let _res1 = tx.try_reserve().expect("reserved 1");
+//        let _res2 = tx.try_reserve().expect("reserved 2");
+//        assert!(matches!(tx.try_reserve(), Err(TryReserveError::Full)));
+//        assert!(matches!(tx.try_reserve(), Err(TryReserveError::Full)));
+//        drop(rx);
+//        assert!(matches!(
+//            tx.try_reserve(),
+//            Err(TryReserveError::Disconnected)
+//        ));
+//    }
+
+//    #[tokio::test]
+//    async fn recv_future_awoken_but_unused() {
+//        let (tx, rx) = channel::<i32>(1);
+//        let mut recv = Box::pin(rx.recv());
+//        let rx2 = rx.clone();
+//        // Try receiving from rx2, but don't drop it yet.
+//        tokio::select! {
+//            biased;
+//            _ = &mut recv => {
+//                panic!("unexpected recv");
+//            }
+//            _ = ReadyFuture {} => {}
+//        }
+//        let task = tokio::spawn(async move { rx2.recv().await });
+//        // Yield the current task so task above can be started.
+//        tokio::time::sleep(Duration::ZERO).await;
+//        tx.try_send(1).expect("sent");
+//        // It would hang without the drop, since the recv would be awoken, but we'd never await for
+//        // it. This is the main flaw of this design where only a single future is awoken at the
+//        // time. Alternatively, we could wake all of them at once, but this would most likely
+//        // result in performance degradation due to lock contention.
+//        drop(recv);
+//        let res = task.await.expect("no panic").expect("receivd");
+//        assert_eq!(res, 1);
+//    }
+
+//    #[tokio::test]
+//    async fn try_reserve_unused_permit_and_send() {
+//        let (tx, rx) = channel::<i32>(1);
+//        let permit = tx.try_reserve().expect("reserved");
+//        let task = tokio::spawn({
+//            let tx = tx.clone();
+//            async move { tx.send(1).await }
+//        });
+//        drop(permit);
+//        task.await.expect("no panic").expect("sent");
+//        assert_eq!(rx.try_recv().expect("recv"), 1);
+//    }
+
+//    #[tokio::test]
+//    async fn try_reserve_unused_permit_and_other_permit() {
+//        let (tx, rx) = channel::<i32>(1);
+//        let permit = tx.try_reserve().expect("reserved");
+//        let task = tokio::spawn({
+//            let tx = tx.clone();
+//            async move { tx.reserve().await.expect("reserved").send(1) }
+//        });
+//        drop(permit);
+//        task.await.expect("no panic");
+//        assert_eq!(rx.try_recv().expect("recv"), 1);
+//    }
+
+//    #[tokio::test]
+//    async fn receiver_close_all() {
+//        let (tx, rx1) = channel::<i32>(3);
+//        let rx2 = rx1.clone();
+//        let permit1 = tx.reserve().await.unwrap();
+//        let permit2 = tx.reserve().await.unwrap();
+//        tx.send(1).await.unwrap();
+//        rx1.close_all();
+//        assert_eq!(rx1.recv().await.unwrap(), 1);
+//        assert_no_recv(&rx1).await;
+//        assert_no_recv(&rx2).await;
+//        permit1.send(2);
+//        permit2.send(3);
+//        assert_eq!(rx1.recv().await.unwrap(), 2);
+//        assert_eq!(rx2.try_recv().unwrap(), 3);
+//        assert_eq!(rx1.recv().await, Err(RecvError));
+//        assert_eq!(rx2.recv().await, Err(RecvError));
+//        assert!(matches!(tx.send(3).await, Err(SendError(3))));
+//    }
+
+//    #[tokio::test]
+//    async fn receiver_close_all_permit_drop() {
+//        let (tx, rx) = channel::<i32>(3);
+//        let permit = tx.reserve().await.unwrap();
+//        rx.close_all();
+//        assert_no_recv(&rx).await;
+//        drop(permit);
+//        assert_eq!(rx.recv().await, Err(RecvError));
+//    }
+
+//    #[tokio::test]
+//    async fn reserve_owned() {
+//        let (tx, rx) = channel::<usize>(4);
+//        let tx = tx.reserve_owned().await.unwrap().send(1);
+//        let tx = tx.reserve_owned().await.unwrap().send(2);
+//        let tx = tx.try_reserve_owned().unwrap().send(3);
+//        let tx = tx.try_reserve_owned().unwrap().release();
+//        let tx = tx.try_reserve_owned().unwrap().send(4);
+//        assert!(matches!(
+//            tx.clone().try_reserve_owned(),
+//            Err(TrySendError::Full(_))
+//        ));
+//        for i in 1..=4 {
+//            assert_eq!(rx.try_recv().unwrap(), i);
+//        }
+//        drop(rx);
+//        assert!(matches!(
+//            tx.clone().reserve_owned().await,
+//            Err(ReserveError)
+//        ));
+//        assert!(matches!(
+//            tx.try_reserve_owned(),
+//            Err(TrySendError::Disconnected(_))
+//        ));
+//    }
+
+//    #[tokio::test]
+//    async fn reserve_many() {
+//        let (tx, rx) = channel::<usize>(10);
+//        let p1 = tx.reserve_many(5).await.unwrap();
+//        let p2 = tx.try_reserve_many(5).unwrap();
+//        assert!(matches!(tx.try_send(11), Err(TrySendError::Full(11))));
+//        for (i, p) in p1.enumerate() {
+//            p.send(i);
+//        }
+//        for (i, p) in p2.enumerate() {
+//            p.send(i + 5);
+//        }
+//        for i in 0..10 {
+//            assert_eq!(rx.try_recv().unwrap(), i);
+//        }
+//    }
+
+//    #[tokio::test]
+//    async fn reserve_many_drop() {
+//        let (tx, _rx) = channel::<usize>(2);
+//        let it = tx.reserve_many(2).await.unwrap();
+//        drop(it);
+//        tx.try_send(1).unwrap();
+//        tx.try_send(2).unwrap();
+//        assert!(matches!(tx.try_send(3), Err(TrySendError::Full(3))));
+//    }
+
+//    #[tokio::test]
+//    async fn reserve_many_drop_halfway() {
+//        let (tx, _rx) = channel::<usize>(4);
+//        let mut it = tx.reserve_many(4).await.unwrap();
+//        it.next().unwrap().send(1);
+//        it.next().unwrap().send(2);
+//        drop(it);
+//        tx.try_send(3).unwrap();
+//        tx.try_send(4).unwrap();
+//        assert!(matches!(tx.try_send(5), Err(TrySendError::Full(5))));
+//    }
+
+//    async fn assert_no_recv<T>(rx: &Receiver<T>)
+//    where
+//        T: std::fmt::Debug + Send + Sync + 'static,
+//    {
+//        tokio::select! {
+//            result = rx.recv() => {
+//                panic!("unexpected recv: {result:?}");
+//            },
+//            _ = tokio::time::sleep(std::time::Duration::ZERO) => {},
+//        }
+//    }
+
+//    struct ReadyFuture {}
+
+//    impl Future for ReadyFuture {
+//        type Output = ();
+
+//        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+//            Poll::Ready(())
+//        }
+//    }
+//}

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -38,6 +38,10 @@ impl<T> LinkedList<T> {
         self.len
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     /// Pushes the value to the head of the list. The resulting [NodeRef] can be used to
     /// remove the entry or add items to either side of it.
     ///

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -19,7 +19,10 @@ pub struct LinkedList<T> {
 unsafe impl<T> Send for LinkedList<T> where T: Send {}
 unsafe impl<T> Sync for LinkedList<T> where T: Sync {}
 
-impl<T> Debug for LinkedList<T> where T: Debug {
+impl<T> Debug for LinkedList<T>
+where
+    T: Debug,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
@@ -709,5 +712,85 @@ mod tests {
         assert!(matches!(list.head(), None));
         assert!(matches!(list.tail(), None));
         assert_eq!(list.iter().collect::<Vec<_>>(), Vec::<&i32>::new());
+    }
+
+    #[test]
+    fn push_head() {
+        let mut list = LinkedList::<i32>::new();
+        assert!(matches!(list.head(), None));
+        assert!(matches!(list.tail(), None));
+        list.push_head(1);
+        list.push_head(2);
+        list.push_head(3);
+        list.push_head(4);
+
+        assert!(matches!(list.head(), Some(&4)));
+        assert!(matches!(list.tail(), Some(&1)));
+        assert_eq!(list.iter().collect::<Vec<_>>(), vec![&4, &3, &2, &1]);
+        assert_eq!(list.iter().rev().collect::<Vec<_>>(), vec![&1, &2, &3, &4]);
+    }
+
+    #[test]
+    fn push_before() {
+        let mut list = LinkedList::<i32>::new();
+        assert!(matches!(list.head(), None));
+        assert!(matches!(list.tail(), None));
+        let node_ref = list.push_head(1);
+        list.push_before(&node_ref, 2).expect("ok");
+        list.push_before(&node_ref, 3).expect("ok");
+        list.push_before(&node_ref, 4).expect("ok");
+
+        assert!(matches!(list.head(), Some(&2)));
+        assert!(matches!(list.tail(), Some(&1)));
+        assert_eq!(list.iter().collect::<Vec<_>>(), vec![&2, &3, &4, &1]);
+        assert_eq!(list.iter().rev().collect::<Vec<_>>(), vec![&1, &4, &3, &2]);
+    }
+
+    #[test]
+    fn push_before_ref() {
+        let mut list = LinkedList::<i32>::new();
+        assert!(matches!(list.head(), None));
+        assert!(matches!(list.tail(), None));
+        let node_ref = list.push_head(1);
+        let node_ref = list.push_before(&node_ref, 2).expect("ok");
+        let node_ref = list.push_before(&node_ref, 3).expect("ok");
+        list.push_before(&node_ref, 4).expect("ok");
+
+        assert!(matches!(list.head(), Some(&4)));
+        assert!(matches!(list.tail(), Some(&1)));
+        assert_eq!(list.iter().collect::<Vec<_>>(), vec![&4, &3, &2, &1]);
+        assert_eq!(list.iter().rev().collect::<Vec<_>>(), vec![&1, &2, &3, &4]);
+    }
+
+    #[test]
+    fn push_after() {
+        let mut list = LinkedList::<i32>::new();
+        assert!(matches!(list.head(), None));
+        assert!(matches!(list.tail(), None));
+        let node_ref = list.push_tail(1);
+        list.push_after(&node_ref, 2).expect("ok");
+        list.push_after(&node_ref, 3).expect("ok");
+        list.push_after(&node_ref, 4).expect("ok");
+
+        assert!(matches!(list.head(), Some(&1)));
+        assert!(matches!(list.tail(), Some(&2)));
+        assert_eq!(list.iter().collect::<Vec<_>>(), vec![&1, &4, &3, &2]);
+        assert_eq!(list.iter().rev().collect::<Vec<_>>(), vec![&2, &3, &4, &1]);
+    }
+
+    #[test]
+    fn push_after_ref() {
+        let mut list = LinkedList::<i32>::new();
+        assert!(matches!(list.head(), None));
+        assert!(matches!(list.tail(), None));
+        let node_ref = list.push_head(1);
+        let node_ref = list.push_after(&node_ref, 2).expect("ok");
+        let node_ref = list.push_after(&node_ref, 3).expect("ok");
+        list.push_after(&node_ref, 4).expect("ok");
+
+        assert!(matches!(list.head(), Some(&1)));
+        assert!(matches!(list.tail(), Some(&4)));
+        assert_eq!(list.iter().collect::<Vec<_>>(), vec![&1, &2, &3, &4]);
+        assert_eq!(list.iter().rev().collect::<Vec<_>>(), vec![&4, &3, &2, &1]);
     }
 }

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -15,6 +15,12 @@ pub struct LinkedList<T> {
     len: usize,
 }
 
+impl<T> Default for LinkedList<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> LinkedList<T> {
     pub fn new() -> Self {
         Self {
@@ -286,6 +292,12 @@ impl<T> LinkedList<T> {
         })
     }
 
+    /// Returns an iterator.
+    pub fn into_iter(self) -> IntoIter<T> {
+        IntoIter::new(self)
+    }
+
+
     /// Removes the element by reference.
     ///
     /// Returns [None] when the item is no longer part of the list.
@@ -334,6 +346,16 @@ impl<'a, T> IntoIterator for &'a LinkedList<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<T> IntoIterator for LinkedList<T> {
+    type Item = T;
+
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.into_iter()
     }
 }
 
@@ -399,6 +421,33 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
         Some(&node.value)
     }
 }
+
+pub struct IntoIter<T> {
+     list: LinkedList<T>,
+}
+
+impl<'a, T> IntoIter<T> {
+    fn new(list: LinkedList<T>) -> Self {
+        Self {
+            list,
+        }
+    }
+}
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        self.list.pop_head()
+    }
+}
+
+impl<T> DoubleEndedIterator for IntoIter<T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.list.pop_tail()
+    }
+}
+
 
 #[derive(Clone)]
 struct HeadTail<T> {

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::sync::atomic::{AtomicUsize, Ordering, AtomicBool};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 /// Implements a double-linked list with O(1) complexity for:
 /// - `push` operation, and
@@ -14,6 +14,9 @@ pub struct LinkedList<T> {
     head_tail: HeadTail<T>,
     len: usize,
 }
+
+unsafe impl<T> Send for LinkedList<T> where T: Send {}
+unsafe impl<T> Sync for LinkedList<T> where T: Sync {}
 
 impl<T> Default for LinkedList<T> {
     fn default() -> Self {
@@ -301,7 +304,6 @@ impl<T> LinkedList<T> {
         IntoIter::new(self)
     }
 
-
     /// Removes the element by reference.
     ///
     /// Returns [None] when the item is no longer part of the list.
@@ -427,14 +429,12 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 }
 
 pub struct IntoIter<T> {
-     list: LinkedList<T>,
+    list: LinkedList<T>,
 }
 
 impl<'a, T> IntoIter<T> {
     fn new(list: LinkedList<T>) -> Self {
-        Self {
-            list,
-        }
+        Self { list }
     }
 }
 
@@ -451,7 +451,6 @@ impl<T> DoubleEndedIterator for IntoIter<T> {
         self.list.pop_tail()
     }
 }
-
 
 #[derive(Clone)]
 struct HeadTail<T> {
@@ -496,6 +495,9 @@ pub struct NodeRef<T> {
     /// Reference to actual node in the list.
     node_ptr: *mut Node<T>,
 }
+
+unsafe impl<T> Send for NodeRef<T> where T: Send {}
+unsafe impl<T> Sync for NodeRef<T> where T: Sync {}
 
 impl<T> Clone for NodeRef<T> {
     fn clone(&self) -> Self {

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -436,7 +436,7 @@ pub struct IntoIter<T> {
     list: LinkedList<T>,
 }
 
-impl<'a, T> IntoIter<T> {
+impl<T> IntoIter<T> {
     fn new(list: LinkedList<T>) -> Self {
         Self { list }
     }

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::sync::atomic::{AtomicUsize, Ordering, AtomicBool};
 
 /// Implements a double-linked list with O(1) complexity for:
 /// - `push` operation, and
@@ -9,6 +10,7 @@ use std::marker::PhantomData;
 /// For every call to `push` `remove` MUST be called before the resulting `NodeRef` is dropped,
 /// or else dropping `NodeRef` will panic.
 pub struct LinkedList<T> {
+    list_ptr: *mut u8,
     head_tail: HeadTail<T>,
     len: usize,
 }
@@ -16,6 +18,7 @@ pub struct LinkedList<T> {
 impl<T> LinkedList<T> {
     pub fn new() -> Self {
         Self {
+            list_ptr: Box::into_raw(Box::new(0)),
             head_tail: HeadTail {
                 head: std::ptr::null_mut(),
                 tail: std::ptr::null_mut(),
@@ -24,15 +27,16 @@ impl<T> LinkedList<T> {
         }
     }
 
+    /// Returns the total number of items in the list.
     pub fn len(&self) -> usize {
         self.len
     }
 
-    /// Pushes an element to the tail of the double linked list with O(1) complexity. After calling
-    /// this method users MUST remove the element from the list before the resulting `NodeRef` is
-    /// dropped.
-    #[must_use]
-    pub fn push(&mut self, value: T) -> NodeRef<T> {
+    /// Pushes the value to the head of the list. The resulting [NodeRef] can be used to
+    /// remove the entry or add items to either side of it.
+    ///
+    /// Complexity: O(1)
+    pub fn push_head(&mut self, value: T) -> NodeRef<T> {
         self.len += 1;
 
         let mut node = Node::new(value);
@@ -43,24 +47,224 @@ impl<T> LinkedList<T> {
             "head and tail should both be null or non-null"
         );
 
-        let tail = unsafe {
-            self.head_tail.tail.as_mut()
-        };
+        let head = unsafe { self.head_tail.head.as_mut() };
+
+        match head {
+            None => {
+                let node_ptr = Box::into_raw(Box::new(node));
+                self.head_tail.head = node_ptr;
+                self.head_tail.tail = node_ptr;
+                NodeRef::new(self.list_ptr, node_ptr)
+            }
+            Some(head) => {
+                node.next = self.head_tail.head;
+                let node_ptr = Box::into_raw(Box::new(node));
+                head.prev = node_ptr;
+                self.head_tail.head = node_ptr;
+                NodeRef::new(self.list_ptr, node_ptr)
+            }
+        }
+    }
+
+    /// Pushes the value to the tail of the list. The resulting [NodeRef] can be used to
+    /// remove the entry or add items to either side of it.
+    ///
+    /// Complexity: O(1)
+    pub fn push_tail(&mut self, value: T) -> NodeRef<T> {
+        self.len += 1;
+
+        let mut node = Node::new(value);
+
+        assert_eq!(
+            self.head_tail.head.is_null(),
+            self.head_tail.tail.is_null(),
+            "head and tail should both be null or non-null"
+        );
+
+        let tail = unsafe { self.head_tail.tail.as_mut() };
 
         match tail {
             None => {
                 let node_ptr = Box::into_raw(Box::new(node));
                 self.head_tail.head = node_ptr;
                 self.head_tail.tail = node_ptr;
-                NodeRef(node_ptr)
-            },
+                NodeRef::new(self.list_ptr, node_ptr)
+            }
             Some(tail) => {
                 node.prev = self.head_tail.tail;
                 let node_ptr = Box::into_raw(Box::new(node));
                 tail.next = node_ptr;
                 self.head_tail.tail = node_ptr;
-                NodeRef(node_ptr)
-            },
+                NodeRef::new(self.list_ptr, node_ptr)
+            }
+        }
+    }
+
+    /// Pushes an element before the referenced item. In case the [NodeRef] is no longer a part
+    /// of this list, it returns `Err(value)`.
+    ///
+    /// Complexity: O(1)
+    pub fn push_before(&mut self, node_ref: &NodeRef<T>, value: T) -> Result<NodeRef<T>, T> {
+        let Some(other_node) = self.get_node_mut(node_ref) else {
+            return Err(value);
+        };
+
+        let mut node = Node::new(value);
+        node.prev = node_ref.node_ptr;
+        node.next = other_node.next;
+
+        let next_ptr = node.next;
+
+        let node_ptr = Box::into_raw(Box::new(node));
+        other_node.next = node_ptr;
+
+        let next = unsafe { next_ptr.as_mut() };
+
+        if let Some(next) = next {
+            next.prev = node_ptr;
+        }
+
+        self.len += 1;
+
+        Ok(NodeRef::new(self.list_ptr, node_ptr))
+    }
+
+    /// Pushes an element after the referenced item. In case the [NodeRef] is no longer a part of
+    /// this list, it returns `Err(value)`.
+    ///
+    /// Complexity: O(1)
+    pub fn push_after(&mut self, node_ref: &NodeRef<T>, value: T) -> Result<NodeRef<T>, T> {
+        let Some(other_node) = self.get_node_mut(node_ref) else {
+            return Err(value);
+        };
+
+        let mut node = Node::new(value);
+        node.prev = other_node.prev;
+        node.next = node_ref.node_ptr;
+
+        let prev_ptr = node.next;
+
+        let node_ptr = Box::into_raw(Box::new(node));
+        other_node.next = node_ptr;
+
+        let prev = unsafe { prev_ptr.as_mut() };
+
+        if let Some(prev) = prev {
+            prev.next = node_ptr;
+        }
+
+        self.len += 1;
+
+        Ok(NodeRef::new(self.list_ptr, node_ptr))
+    }
+
+    /// Removes the first item in the list if any and returns it.
+    ///
+    /// Complexity: O(1)
+    pub fn pop_head(&mut self) -> Option<T> {
+        assert_eq!(
+            self.head_tail.head.is_null(),
+            self.head_tail.tail.is_null(),
+            "head and tail should both be null or non-null"
+        );
+
+        if self.head_tail.head.is_null() {
+            return None;
+        }
+
+        let node = unsafe { Box::from_raw(self.head_tail.head) };
+
+        if self.head_tail.head == self.head_tail.tail {
+            self.head_tail.head = std::ptr::null_mut();
+            self.head_tail.tail = std::ptr::null_mut();
+        } else {
+            self.head_tail.head = node.next;
+
+            if let Some(next) = unsafe { node.next.as_mut() } {
+                next.prev = std::ptr::null_mut();
+            }
+        }
+
+        Some(node.value)
+    }
+
+    /// Removes the last item in the list if any and returns it.
+    ///
+    /// Complexity: O(1)
+    pub fn pop_tail(&mut self) -> Option<T> {
+        assert_eq!(
+            self.head_tail.head.is_null(),
+            self.head_tail.tail.is_null(),
+            "head and tail should both be null or non-null"
+        );
+
+        if self.head_tail.tail.is_null() {
+            return None;
+        }
+
+        let node = unsafe { Box::from_raw(self.head_tail.tail) };
+
+        if self.head_tail.head == self.head_tail.tail {
+            self.head_tail.head = std::ptr::null_mut();
+            self.head_tail.tail = std::ptr::null_mut();
+        } else {
+            self.head_tail.tail = node.prev;
+
+            if let Some(prev) = unsafe { node.prev.as_mut() } {
+                prev.next = std::ptr::null_mut();
+            }
+        }
+
+        Some(node.value)
+    }
+
+    /// Gets a reference to the value by its ref.
+    ///
+    /// In case the item was removed from the list it returns [None].
+    ///
+    /// Complexity: O(1)
+    pub fn get(&self, node_ref: &NodeRef<T>) -> Option<&T> {
+        self.get_node(node_ref).map(|node| &node.value)
+    }
+
+    /// Gets a mutable reference to the value by its ref.
+    ///
+    /// In case the item was removed from the list it returns [None].
+    ///
+    /// Complexity: O(1)
+    pub fn get_mut(&mut self, node_ref: &NodeRef<T>) -> Option<&mut T> {
+        self.get_node_mut(node_ref).map(|node| &mut node.value)
+    }
+
+    fn get_node(&self, node_ref: &NodeRef<T>) -> Option<&Node<T>> {
+        if node_ref.list_ptr != self.list_ptr {
+            // This ref belongs to a different list instance or has been removed.
+            return None;
+        }
+
+        let node = unsafe { node_ref.node_ptr.as_ref()? };
+
+        if node.ref_count.load(Ordering::Relaxed) < 2 {
+            // This node was removed from the list.
+            None
+        } else {
+            Some(node)
+        }
+    }
+
+    fn get_node_mut(&mut self, node_ref: &NodeRef<T>) -> Option<&mut Node<T>> {
+        if node_ref.list_ptr != self.list_ptr {
+            // This ref belongs to a different list instance or has been removed.
+            return None;
+        }
+
+        let node = unsafe { node_ref.node_ptr.as_mut()? };
+
+        if node.removed.load(Ordering::Relaxed) {
+            // This node was removed from the list.
+            None
+        } else {
+            Some(node)
         }
     }
 
@@ -69,28 +273,37 @@ impl<T> LinkedList<T> {
         unsafe { self.head_tail.head.as_ref().map(|node| &node.value) }
     }
 
-    /// Returns a reference to the first element, if any.
+    /// Returns a reference to the last element, if any.
     pub fn tail(&self) -> Option<&T> {
         unsafe { self.head_tail.tail.as_ref().map(|node| &node.value) }
     }
 
+    /// Returns an iterator.
     pub fn iter(&self) -> Iter<'_, T> {
-        Iter {
-            next: self.head_tail.head,
-            phantom: Default::default(),
-        }
+        Iter::new(HeadTail {
+            head: self.head_tail.head,
+            tail: self.head_tail.tail,
+        })
     }
 
-    /// Removes the element with O(1) complexity.
-    pub fn remove(&mut self, mut node_ref: NodeRef<T>) -> T {
-        let node_ptr = node_ref.0;
+    /// Removes the element by reference.
+    ///
+    /// Returns [None] when the item is no longer part of the list.
+    ///
+    /// Complexity: O(1).
+    pub fn remove(&mut self, mut node_ref: NodeRef<T>) -> Option<T> {
+        if node_ref.list_ptr != self.list_ptr {
+            return None;
+        }
+
+        let node_ptr = node_ref.node_ptr;
 
         let node = unsafe { Box::from_raw(node_ptr) };
 
         let value = node.remove(&mut self.head_tail);
 
-        // Don't panic in drop.
-        node_ref.0 = std::ptr::null_mut();
+        // Detach from the list.
+        node_ref.list_ptr = std::ptr::null_mut();
 
         println!("setting node_ref.0 to null");
 
@@ -98,27 +311,96 @@ impl<T> LinkedList<T> {
 
         self.len -= 1;
 
-        value
+        Some(value)
     }
 }
 
-struct Iter<'a, T> {
-    next: *mut Node<T>,
+impl<T> FromIterator<T> for LinkedList<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut list = Self::new();
+
+        for item in iter {
+            list.push_tail(item);
+        }
+
+        list
+    }
+}
+
+impl<'a, T> IntoIterator for &'a LinkedList<T> {
+    type Item = &'a T;
+
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<T> Drop for LinkedList<T> {
+    fn drop(&mut self) {
+        unsafe { drop(Box::from_raw(self.list_ptr)) }
+
+        let mut node_ptr = self.head_tail.head;
+
+        while let Some(node) = unsafe { node_ptr.as_ref() } {
+            let next_ptr = node.next;
+
+            maybe_drop_node(node_ptr);
+
+            node_ptr = next_ptr;
+        }
+    }
+}
+
+pub struct Iter<'a, T> {
+    head_tail: HeadTail<T>,
     phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T> Iter<'a, T> {
+    fn new(head_tail: HeadTail<T>) -> Self {
+        Self {
+            head_tail,
+            phantom: Default::default(),
+        }
+    }
+
+    fn check_done(&mut self) {
+        if self.head_tail.head == self.head_tail.tail {
+            self.head_tail.head = std::ptr::null_mut();
+            self.head_tail.tail = std::ptr::null_mut();
+        }
+    }
 }
 
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
-        let node = unsafe { self.next.as_ref()? };
+        let node = unsafe { self.head_tail.head.as_ref()? };
 
-        self.next = node.next;
+        self.check_done();
+
+        self.head_tail.head = node.next;
 
         Some(&node.value)
     }
 }
 
+impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let node = unsafe { self.head_tail.tail.as_ref()? };
+
+        self.check_done();
+
+        self.head_tail.tail = node.prev;
+
+        Some(&node.value)
+    }
+}
+
+#[derive(Clone)]
 struct HeadTail<T> {
     head: *mut Node<T>,
     tail: *mut Node<T>,
@@ -128,19 +410,66 @@ struct Node<T> {
     value: T,
     prev: *mut Node<T>,
     next: *mut Node<T>,
+    /// Tracks the number of references. There are only two possible references, the one held by
+    /// [LinkedList], and the one from [NodeRef].
+    ref_count: AtomicUsize,
+    removed: AtomicBool,
 }
 
-pub struct NodeRef<T>(*mut Node<T>);
+fn maybe_drop_node<T>(node_ptr: *mut Node<T>) {
+    let node = unsafe { node_ptr.as_ref().expect("node") };
 
-impl<T> AsRef<T> for NodeRef<T> {
-    fn as_ref(&self) -> &T {
-        unsafe { &(*self.0).value }
+    let ref_count = node.ref_count.fetch_sub(1, Ordering::Relaxed);
+
+    if ref_count == 1 {
+        let node = unsafe { Box::from_raw(node_ptr) };
+        drop(node);
+    }
+}
+
+/// Contains a reference to a value that was added to the [LinkedList].
+///
+/// Note that the value it points to might be removed from the list while this reference is held.
+/// However, there are no race conditions because we always dereference the inner pointer from
+/// within the list's functions.
+///
+/// The actual value will be dropped when both conditions are satisfied:
+///
+/// 1. The [NodeRef] is dropped and the item is removed, and
+/// 2. The item is dropped from the [LinkedList].
+pub struct NodeRef<T> {
+    /// Used to check whether [NodeRef] is associated to [LinkedList].
+    list_ptr: *mut u8,
+    /// Reference to actual node in the list.
+    node_ptr: *mut Node<T>,
+}
+
+impl<T> Clone for NodeRef<T> {
+    fn clone(&self) -> Self {
+        unsafe {
+            self.node_ptr
+                .as_mut()
+                .expect("deref")
+                .ref_count
+                .fetch_add(1, Ordering::Relaxed);
+        }
+
+        Self {
+            list_ptr: self.list_ptr,
+            node_ptr: self.node_ptr,
+        }
     }
 }
 
 impl<T> NodeRef<T> {
-    fn as_node(&self) -> &Node<T> {
-        unsafe { &(*self.0) }
+    fn new(list_ptr: *mut u8, node_ptr: *mut Node<T>) -> Self {
+        Self { list_ptr, node_ptr }
+    }
+}
+
+impl<T> Drop for NodeRef<T> {
+    fn drop(&mut self) {
+        maybe_drop_node(self.node_ptr);
     }
 }
 
@@ -150,25 +479,21 @@ impl<T> AsRef<T> for Node<T> {
     }
 }
 
-impl<T> Drop for NodeRef<T> {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            let node = unsafe { &*self.0 };
-            panic!("NodeRef dropped without beng removed from the LinkedList")
-        }
-    }
-}
-
 impl<T> Node<T> {
     fn new(value: T) -> Node<T> {
         Node {
             value,
             prev: std::ptr::null_mut(),
             next: std::ptr::null_mut(),
+            // One ref for LinkedList, the other for NodeRef.
+            ref_count: AtomicUsize::from(2),
+            removed: AtomicBool::from(false),
         }
     }
 
     fn remove(self, head_tail: &mut HeadTail<T>) -> T {
+        self.removed.store(true, Ordering::Relaxed);
+
         let value = self.value;
 
         assert_eq!(
@@ -207,11 +532,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn add_remove_drop() {
+    fn push_tail_remove_drop() {
         let mut list = LinkedList::<i32>::new();
         assert!(matches!(list.head(), None));
         assert!(matches!(list.tail(), None));
-        let node_ref = list.push(123);
+        let node_ref = list.push_tail(123);
         assert!(matches!(list.head(), Some(&123)));
         assert!(matches!(list.tail(), Some(&123)));
         list.remove(node_ref);
@@ -221,14 +546,81 @@ mod tests {
     }
 
     #[test]
+    fn push_head_remove_drop() {
+        let mut list = LinkedList::<i32>::new();
+        assert!(matches!(list.head(), None));
+        assert!(matches!(list.tail(), None));
+        let node_ref = list.push_head(123);
+        assert!(matches!(list.head(), Some(&123)));
+        assert!(matches!(list.tail(), Some(&123)));
+        list.remove(node_ref);
+        assert!(matches!(list.head(), None));
+        assert!(matches!(list.tail(), None));
+        drop(list);
+    }
+
+    #[test]
+    fn collect_iter() {
+        let list: LinkedList<_> = (1..=4i32).collect();
+
+        assert_eq!(list.iter().collect::<Vec<_>>(), vec![&1, &2, &3, &4]);
+        assert_eq!(list.iter().rev().collect::<Vec<_>>(), vec![&4, &3, &2, &1]);
+    }
+
+    #[test]
+    fn into_iter_ref() {
+        let mut range = 1..=4i32;
+        let list: LinkedList<_> = range.clone().collect();
+        for got in &list {
+            let want = range.next().unwrap();
+            assert_eq!(&want, got);
+        }
+    }
+
+    #[test]
+    fn pop_head_tail() {
+        let mut list: LinkedList<_> = (1..=4i32).collect();
+
+        assert_eq!(list.pop_head(), Some(1));
+        assert_eq!(list.pop_tail(), Some(4));
+        assert_eq!(list.pop_head(), Some(2));
+        assert_eq!(list.pop_tail(), Some(3));
+        assert_eq!(list.pop_head(), None);
+        assert_eq!(list.pop_tail(), None);
+    }
+
+    #[test]
+    fn clone_node_ref() {
+        let mut list = LinkedList::new();
+        let node_ref1 = list.push_tail(1);
+        let node_ref2 = node_ref1.clone();
+        let node_ref3 = node_ref2.clone();
+
+        assert_eq!(list.get(&node_ref1), Some(&1));
+        assert_eq!(list.get(&node_ref2), Some(&1));
+        assert_eq!(list.get(&node_ref3), Some(&1));
+
+        drop(node_ref1);
+        assert_eq!(list.get(&node_ref2), Some(&1));
+        assert_eq!(list.get(&node_ref3), Some(&1));
+
+        drop(node_ref2);
+        assert_eq!(list.get(&node_ref3), Some(&1));
+
+        drop(node_ref3);
+        assert_eq!(list.pop_head(), Some(1));
+        assert_eq!(list.pop_head(), None);
+    }
+
+    #[test]
     fn add_remove_multiple_drop() {
         let mut list = LinkedList::<i32>::new();
         assert!(matches!(list.head(), None));
         assert!(matches!(list.tail(), None));
-        let node_ref1 = list.push(1);
-        let node_ref2 = list.push(2);
-        let node_ref3 = list.push(3);
-        let node_ref4 = list.push(4);
+        let node_ref1 = list.push_tail(1);
+        let node_ref2 = list.push_tail(2);
+        let node_ref3 = list.push_tail(3);
+        let node_ref4 = list.push_tail(4);
 
         assert!(matches!(list.head(), Some(&1)));
         assert!(matches!(list.tail(), Some(&4)));

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1,0 +1,257 @@
+use std::marker::PhantomData;
+
+/// Implements a double-linked list with O(1) complexity for:
+/// - `push` operation, and
+/// - `remove` of _any_ node
+///
+/// with the following caveat:
+///
+/// For every call to `push` `remove` MUST be called before the resulting `NodeRef` is dropped,
+/// or else dropping `NodeRef` will panic.
+pub struct LinkedList<T> {
+    head_tail: HeadTail<T>,
+    len: usize,
+}
+
+impl<T> LinkedList<T> {
+    pub fn new() -> Self {
+        Self {
+            head_tail: HeadTail {
+                head: std::ptr::null_mut(),
+                tail: std::ptr::null_mut(),
+            },
+            len: 0,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Pushes an element to the tail of the double linked list with O(1) complexity. After calling
+    /// this method users MUST remove the element from the list before the resulting `NodeRef` is
+    /// dropped.
+    #[must_use]
+    pub fn push(&mut self, value: T) -> NodeRef<T> {
+        self.len += 1;
+
+        let mut node = Node::new(value);
+
+        assert_eq!(
+            self.head_tail.head.is_null(),
+            self.head_tail.tail.is_null(),
+            "head and tail should both be null or non-null"
+        );
+
+        let tail = unsafe {
+            self.head_tail.tail.as_mut()
+        };
+
+        match tail {
+            None => {
+                let node_ptr = Box::into_raw(Box::new(node));
+                self.head_tail.head = node_ptr;
+                self.head_tail.tail = node_ptr;
+                NodeRef(node_ptr)
+            },
+            Some(tail) => {
+                node.prev = self.head_tail.tail;
+                let node_ptr = Box::into_raw(Box::new(node));
+                tail.next = node_ptr;
+                self.head_tail.tail = node_ptr;
+                NodeRef(node_ptr)
+            },
+        }
+    }
+
+    /// Returns a reference to the first element, if any.
+    pub fn head(&self) -> Option<&T> {
+        unsafe { self.head_tail.head.as_ref().map(|node| &node.value) }
+    }
+
+    /// Returns a reference to the first element, if any.
+    pub fn tail(&self) -> Option<&T> {
+        unsafe { self.head_tail.tail.as_ref().map(|node| &node.value) }
+    }
+
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter {
+            next: self.head_tail.head,
+            phantom: Default::default(),
+        }
+    }
+
+    /// Removes the element with O(1) complexity.
+    pub fn remove(&mut self, mut node_ref: NodeRef<T>) -> T {
+        let node_ptr = node_ref.0;
+
+        let node = unsafe { Box::from_raw(node_ptr) };
+
+        let value = node.remove(&mut self.head_tail);
+
+        // Don't panic in drop.
+        node_ref.0 = std::ptr::null_mut();
+
+        println!("setting node_ref.0 to null");
+
+        drop(node_ref);
+
+        self.len -= 1;
+
+        value
+    }
+}
+
+struct Iter<'a, T> {
+    next: *mut Node<T>,
+    phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<&'a T> {
+        let node = unsafe { self.next.as_ref()? };
+
+        self.next = node.next;
+
+        Some(&node.value)
+    }
+}
+
+struct HeadTail<T> {
+    head: *mut Node<T>,
+    tail: *mut Node<T>,
+}
+
+struct Node<T> {
+    value: T,
+    prev: *mut Node<T>,
+    next: *mut Node<T>,
+}
+
+pub struct NodeRef<T>(*mut Node<T>);
+
+impl<T> AsRef<T> for NodeRef<T> {
+    fn as_ref(&self) -> &T {
+        unsafe { &(*self.0).value }
+    }
+}
+
+impl<T> NodeRef<T> {
+    fn as_node(&self) -> &Node<T> {
+        unsafe { &(*self.0) }
+    }
+}
+
+impl<T> AsRef<T> for Node<T> {
+    fn as_ref(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<T> Drop for NodeRef<T> {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            let node = unsafe { &*self.0 };
+            panic!("NodeRef dropped without beng removed from the LinkedList")
+        }
+    }
+}
+
+impl<T> Node<T> {
+    fn new(value: T) -> Node<T> {
+        Node {
+            value,
+            prev: std::ptr::null_mut(),
+            next: std::ptr::null_mut(),
+        }
+    }
+
+    fn remove(self, head_tail: &mut HeadTail<T>) -> T {
+        let value = self.value;
+
+        assert_eq!(
+            head_tail.head.is_null(),
+            head_tail.tail.is_null(),
+            "head and tail should both be null or non-null"
+        );
+
+        if !self.prev.is_null() {
+            unsafe { (*self.prev).next = self.next }
+        } else {
+            // This was the head.
+            head_tail.head = self.next
+        }
+
+        if !self.next.is_null() {
+            unsafe { (*self.next).prev = self.prev }
+        } else {
+            // This was the tail.
+            head_tail.tail = self.prev
+        }
+
+        // Last element in the list is both the head and the tail.
+        if head_tail.head.is_null() && !head_tail.tail.is_null() {
+            head_tail.head = head_tail.tail
+        } else if !head_tail.head.is_null() && head_tail.tail.is_null() {
+            head_tail.tail = head_tail.head
+        }
+
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_remove_drop() {
+        let mut list = LinkedList::<i32>::new();
+        assert!(matches!(list.head(), None));
+        assert!(matches!(list.tail(), None));
+        let node_ref = list.push(123);
+        assert!(matches!(list.head(), Some(&123)));
+        assert!(matches!(list.tail(), Some(&123)));
+        list.remove(node_ref);
+        assert!(matches!(list.head(), None));
+        assert!(matches!(list.tail(), None));
+        drop(list);
+    }
+
+    #[test]
+    fn add_remove_multiple_drop() {
+        let mut list = LinkedList::<i32>::new();
+        assert!(matches!(list.head(), None));
+        assert!(matches!(list.tail(), None));
+        let node_ref1 = list.push(1);
+        let node_ref2 = list.push(2);
+        let node_ref3 = list.push(3);
+        let node_ref4 = list.push(4);
+
+        assert!(matches!(list.head(), Some(&1)));
+        assert!(matches!(list.tail(), Some(&4)));
+        assert_eq!(list.iter().collect::<Vec<_>>(), vec![&1, &2, &3, &4]);
+
+        list.remove(node_ref1);
+        assert!(matches!(list.head(), Some(&2)));
+        assert!(matches!(list.tail(), Some(&4)));
+        assert_eq!(list.iter().collect::<Vec<_>>(), vec![&2, &3, &4]);
+
+        list.remove(node_ref3);
+        assert!(matches!(list.head(), Some(&2)));
+        assert!(matches!(list.tail(), Some(&4)));
+        assert_eq!(list.iter().collect::<Vec<_>>(), vec![&2, &4]);
+
+        list.remove(node_ref4);
+        assert!(matches!(list.head(), Some(&2)));
+        assert!(matches!(list.tail(), Some(&2)));
+        assert_eq!(list.iter().collect::<Vec<_>>(), vec![&2]);
+
+        list.remove(node_ref2);
+        assert!(matches!(list.head(), None));
+        assert!(matches!(list.tail(), None));
+        assert_eq!(list.iter().collect::<Vec<_>>(), Vec::<&i32>::new());
+    }
+}

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -123,18 +123,20 @@ impl<T> LinkedList<T> {
         };
 
         let mut node = Node::new(value);
-        node.prev = node_ref.node_ptr;
-        node.next = other_node.next;
+        node.prev = other_node.prev;
+        node.next = node_ref.node_ptr;
 
-        let next_ptr = node.next;
+        let prev_ptr = node.prev;
 
         let node_ptr = Box::into_raw(Box::new(node));
-        other_node.next = node_ptr;
+        other_node.prev = node_ptr;
 
-        let next = unsafe { next_ptr.as_mut() };
+        let prev = unsafe { prev_ptr.as_mut() };
 
-        if let Some(next) = next {
-            next.prev = node_ptr;
+        if let Some(prev) = prev {
+            prev.next = node_ptr;
+        } else {
+            self.head_tail.head = node_ptr;
         }
 
         self.len += 1;
@@ -152,18 +154,20 @@ impl<T> LinkedList<T> {
         };
 
         let mut node = Node::new(value);
-        node.prev = other_node.prev;
-        node.next = node_ref.node_ptr;
+        node.prev = node_ref.node_ptr;
+        node.next = other_node.next;
 
-        let prev_ptr = node.next;
+        let next_ptr = node.next;
 
         let node_ptr = Box::into_raw(Box::new(node));
         other_node.next = node_ptr;
 
-        let prev = unsafe { prev_ptr.as_mut() };
+        let next = unsafe { next_ptr.as_mut() };
 
-        if let Some(prev) = prev {
-            prev.next = node_ptr;
+        if let Some(next) = next {
+            next.prev = node_ptr;
+        } else {
+            self.head_tail.tail = node_ptr;
         }
 
         self.len += 1;

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
@@ -17,6 +18,12 @@ pub struct LinkedList<T> {
 
 unsafe impl<T> Send for LinkedList<T> where T: Send {}
 unsafe impl<T> Sync for LinkedList<T> where T: Sync {}
+
+impl<T> Debug for LinkedList<T> where T: Debug {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
 
 impl<T> Default for LinkedList<T> {
     fn default() -> Self {
@@ -326,8 +333,6 @@ impl<T> LinkedList<T> {
 
         // Detach from the list.
         node_ref.list_ptr = std::ptr::null_mut();
-
-        println!("setting node_ref.0 to null");
 
         drop(node_ref);
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -27,15 +27,15 @@ impl<T> Queue<T> {
         }
     }
 
-    /// Returns the number of queued items, including values and reserved spots.
-    pub fn len(&self) -> usize {
-        self.len
-    }
+    // /// Returns the number of queued items, including values and reserved spots.
+    // pub fn len(&self) -> usize {
+    //     self.len
+    // }
 
-    /// Returns the maximum number of items in the Queue. This value never changes.
-    pub fn cap(&self) -> usize {
-        self.cap
-    }
+    // /// Returns the maximum number of items in the Queue. This value never changes.
+    // pub fn cap(&self) -> usize {
+    //     self.cap
+    // }
 
     pub fn has_room_for(&self, count: usize) -> bool {
         self.len + count <= self.cap

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -7,7 +7,7 @@ use crate::linked_list::{LinkedList, NodeRef};
 /// The implemented methods panic when used incorrectly. This is because incorrect usage is a bug
 /// in the codebase and any sort of error handling would result in incorrect behavior.
 pub struct Queue<T> {
-    list: LinkedList<Spot<T>>,
+    pub list: LinkedList<Spot<T>>,
     len: usize,
     cap: usize,
 }
@@ -38,6 +38,10 @@ impl<T> Queue<T> {
     // }
 
     pub fn has_room_for(&self, count: usize) -> bool {
+        println!(
+            "has_room_for {:?} + {:?} <= {:?}",
+            self.len, count, self.cap
+        );
         self.len + count <= self.cap
     }
 
@@ -55,6 +59,7 @@ impl<T> Queue<T> {
         }
 
         let reservation = self.list.push_tail(Spot::Reserved(count));
+        self.len += count;
 
         Some(reservation)
     }
@@ -66,10 +71,13 @@ impl<T> Queue<T> {
                 let spot = self.list.pop_head().expect("value");
 
                 match spot {
-                    Spot::Value(value) => Recv::Value(value),
+                    Spot::Value(value) => {
+                        self.len -= 1;
+                        Recv::Value(value)
+                    }
                     Spot::Reserved(_) => unreachable!(),
                 }
-            },
+            }
             Some(Spot::Reserved(_)) => Recv::Pending,
             None => Recv::Empty,
         }
@@ -96,8 +104,10 @@ impl<T> Queue<T> {
         let value = Spot::Value(value);
 
         if *count == 0 {
+            println!("setting value");
             *spot = value;
         } else {
+            println!("pushing before");
             self.list
                 .push_before(&reservation, value)
                 .expect("push_before failed");
@@ -119,6 +129,8 @@ impl<T> Queue<T> {
             panic!("count {count} > cur_count {cur_count}");
         }
 
+        self.len -= count;
+
         if *cur_count == count {
             self.list
                 .remove(reservation)
@@ -127,7 +139,7 @@ impl<T> Queue<T> {
             *cur_count -= count;
         }
 
-        return true
+        return true;
     }
 }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -27,16 +27,6 @@ impl<T> Queue<T> {
         }
     }
 
-    // /// Returns the number of queued items, including values and reserved spots.
-    // pub fn len(&self) -> usize {
-    //     self.len
-    // }
-
-    // /// Returns the maximum number of items in the Queue. This value never changes.
-    // pub fn cap(&self) -> usize {
-    //     self.cap
-    // }
-
     pub fn has_room_for(&self, count: usize) -> bool {
         println!(
             "has_room_for {:?} + {:?} <= {:?}",
@@ -139,7 +129,7 @@ impl<T> Queue<T> {
             *cur_count -= count;
         }
 
-        return true;
+        true
     }
 }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -28,10 +28,6 @@ impl<T> Queue<T> {
     }
 
     pub fn has_room_for(&self, count: usize) -> bool {
-        println!(
-            "has_room_for {:?} + {:?} <= {:?}",
-            self.len, count, self.cap
-        );
         self.len + count <= self.cap
     }
 
@@ -94,10 +90,8 @@ impl<T> Queue<T> {
         let value = Spot::Value(value);
 
         if *count == 0 {
-            println!("setting value");
             *spot = value;
         } else {
-            println!("pushing before");
             self.list
                 .push_before(&reservation, value)
                 .expect("push_before failed");

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,0 +1,156 @@
+use std::fmt::Debug;
+
+use crate::linked_list::{LinkedList, NodeRef};
+
+/// A wrapper around [LinkedList] that processes reservations, writes and reads.
+///
+/// The implemented methods panic when used incorrectly. This is because incorrect usage is a bug
+/// in the codebase and any sort of error handling would result in incorrect behavior.
+pub struct Queue<T> {
+    list: LinkedList<Spot<T>>,
+    len: usize,
+    cap: usize,
+}
+
+impl<T> Queue<T> {
+    /// Creates a new instance with the provided capacity.
+    pub fn new(cap: usize) -> Self {
+        Self {
+            list: LinkedList::new(),
+            len: 0,
+            cap,
+        }
+    }
+
+    /// Returns the number of queued items, including values and reserved spots.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns the maximum number of items in the Queue. This value never changes.
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+
+    /// Attempts to reserve a number of spots in the queue if there is room.
+    pub fn try_reserve(&mut self, count: usize) -> Option<NodeRef<Spot<T>>> {
+        if self.len + count > self.cap {
+            return None;
+        }
+
+        let reservation = self.list.push_tail(Spot::Reserved(count));
+
+        Some(reservation)
+    }
+
+    /// Reads the next ready value, if any.
+    pub fn read_next_value(&mut self) -> Option<T> {
+        let Spot::Value(_) = self.list.head()? else {
+            return None;
+        };
+
+        let spot = self.list.pop_head().expect("no value to pop: just checked");
+
+        match spot {
+            Spot::Value(value) => Some(value),
+            Spot::Reserved(_) => unreachable!(),
+        }
+    }
+
+    /// Replaces a single reserved spots with a value.
+    pub fn write(&mut self, reservation: &NodeRef<Spot<T>>, value: T) {
+        let spot = self
+            .list
+            .get_mut(reservation)
+            .expect("reservation not found");
+
+        let count = match spot {
+            Spot::Value(_) => panic!("illegal: called set_value on value"),
+            Spot::Reserved(count) => count,
+        };
+
+        if *count == 0 {
+            panic!("invalid state: found reservation with zero spots left");
+        }
+
+        *count -= 1;
+
+        let value = Spot::Value(value);
+
+        if *count == 0 {
+            *spot = value;
+        } else {
+            self.list
+                .push_before(reservation, value)
+                .expect("push_before failed");
+        }
+    }
+
+    pub fn release(&mut self, reservation: NodeRef<Spot<T>>, release: Release) {
+        match release {
+            Release::All => {
+                let spot = self
+                    .list
+                    .remove(reservation)
+                    .expect("reservation not found");
+
+                let count = match spot {
+                    Spot::Reserved(count) => count,
+                    Spot::Value(_) => panic!("illegal: called release on value"),
+                };
+
+                self.len -= count;
+            }
+            Release::Count(count_to_remove) => {
+                let spot = self
+                    .list
+                    .get_mut(&reservation)
+                    .expect("reservation not found");
+
+                let count = match spot {
+                    Spot::Reserved(count) => count,
+                    Spot::Value(_) => panic!("illegal: called release on value"),
+                };
+
+                if count_to_remove > *count {
+                    panic!("count_to_remove {count_to_remove} > count {count}");
+                }
+
+                if *count == count_to_remove {
+                    self.list
+                        .remove(reservation)
+                        .expect("reservation not found");
+                } else {
+                    *count -= count_to_remove;
+                }
+            }
+        };
+    }
+}
+
+/// Describes how many reserved spots to release.
+pub enum Release {
+    /// Uesd to release all reserved spots for the reference (e.g. in case of dropping an
+    /// iterator).
+    All,
+    /// Used to release a single reserved spot for the reference (e.g. for a single permit).
+    Count(usize),
+}
+
+/// A spot in the queue.
+pub enum Spot<T> {
+    /// An actual value that is meant to be read.
+    Value(T),
+    /// A reserved spot which will block the reads once it is the until a value is written or the
+    /// spot released.
+    Reserved(usize),
+}
+
+impl<T> Debug for Spot<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Value(_) => f.write_str("Spot::Value"),
+            Self::Reserved(count) => write!(f, "Spot::Count({count})"),
+        }
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -148,7 +148,7 @@ where
         let waker = {
             let mut inner = self.inner_mut();
             inner.queue.send(reservation, value);
-            inner.recv_futures.head().map(|waker| waker.clone())
+            inner.recv_futures.head().cloned()
         };
 
         if let Some(waker) = waker {
@@ -170,7 +170,7 @@ where
                         .send_futures
                         .head()
                         .filter(|send_waker| inner.queue.has_room_for(send_waker.count))
-                        .map(|send_waker| send_waker.clone())
+                        .map(|send_waker| send_waker.waker.clone())
                 })
                 .flatten()
         };
@@ -283,7 +283,6 @@ where
     }
 }
 
-#[derive(Clone)]
 pub struct SendWaker {
     count: usize,
     waker: Waker,
@@ -401,7 +400,7 @@ where
         if !self.queue.can_recv() {
             // NOTE: Not calling pop_head() because calling wake() does not guarantee that the future will be
             // chosen (e.g. in a tokio::select!)
-            self.recv_futures.head().map(|waker| waker.clone())
+            self.recv_futures.head().cloned()
         } else {
             None
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -119,10 +119,7 @@ where
                 Poll::Ready(Ok(reservation))
             }
             Err(TryReserveError::Full) => {
-                let send_future = SendWaker {
-                    count,
-                    waker: cx.waker().clone(),
-                };
+                let send_future = SendWaker::new(count, cx.waker().clone());
 
                 match waker_ref {
                     None => {
@@ -296,16 +293,8 @@ impl SendWaker {
         Self { count, waker }
     }
 
-    pub fn count(&self) -> usize {
-        self.count
-    }
-
     pub fn wake(self) {
         self.waker.wake()
-    }
-
-    pub fn wake_by_ref(&self) {
-        self.waker.wake_by_ref();
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,356 @@
+use std::ops::DerefMut;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+use crate::linked_list::{LinkedList, NodeRef};
+use crate::queue::{Queue, Spot};
+use crate::{Receiver, ReserveError, Sender, TryReserveError};
+
+pub struct State<T> {
+    inner: Arc<Mutex<InnerState<T>>>,
+}
+
+impl<T> State<T> {}
+
+impl<T> Clone for State<T>
+where
+    T: Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T> State<T>
+where
+    T: Send + Sync + 'static,
+{
+    pub fn new(cap: usize) -> Self {
+        State {
+            inner: Arc::new(Mutex::new(InnerState::new(cap))),
+        }
+    }
+
+    pub fn inner_mut(&self) -> impl DerefMut<Target = InnerState<T>> + '_ {
+        self.inner.lock().unwrap()
+    }
+
+    // fn next_waker_id(&self) -> wakerid {
+    //     self.inner_mut().next_waker_id()
+    // }
+
+    pub fn new_sender(&self) -> Sender<T> {
+        self.inner_mut().senders_count += 1;
+        Sender::new(self.clone())
+    }
+
+    pub fn new_receiver(&self) -> Receiver<T> {
+        self.inner_mut().receivers_count += 1;
+        Receiver::new(self.clone())
+    }
+
+    // fn wake_all(wakers: option<impl iterator<item = waker>>) {
+    //     if let some(wakers) = wakers {
+    //         for waker in wakers {
+    //             waker.wake()
+    //         }
+    //     }
+    // }
+
+    pub fn close_all_receivers(&self) {
+        let (send_futures, recv_futures) = {
+            let mut inner = self.inner_mut();
+            // inner.disconnected = true;
+
+            (
+                inner.mark_disconnected_and_take_send_futures(),
+                inner.mark_disconnected_and_take_recv_futures(),
+            )
+        };
+
+        for send_future in send_futures {
+            send_future.wake();
+        }
+
+        for recv_future in recv_futures {
+            recv_future.wake()
+        }
+    }
+
+    pub fn drop_sender(&self) {
+        let recv_futures = {
+            let mut inner = self.inner_mut();
+            inner.senders_count -= 1;
+
+            (inner.senders_count == 0).then(|| inner.mark_disconnected_and_take_recv_futures())
+        };
+
+        if let Some(recv_futures) = recv_futures {
+            for recv_future in recv_futures {
+                recv_future.wake();
+            }
+        }
+    }
+
+    pub fn drop_receiver(&self) {
+        let send_futures = {
+            let mut inner = self.inner_mut();
+            inner.receivers_count -= 1;
+
+            (inner.receivers_count == 0).then(|| inner.mark_disconnected_and_take_send_futures())
+        };
+
+        if let Some(send_futures) = send_futures {
+            for send_future in send_futures {
+                send_future.wake();
+            }
+        }
+    }
+
+    pub fn try_reserve(&self, count: usize) -> Result<NodeRef<Spot<T>>, TryReserveError> {
+        let mut inner = self.inner_mut();
+        inner.try_reserve(count)
+    }
+
+    pub fn reserve(
+        &self,
+        count: usize,
+        cx: &mut Context<'_>,
+        send_future: &mut Option<NodeRef<SendWaker>>,
+    ) -> Poll<Result<NodeRef<Spot<T>>, ReserveError>> {
+        let mut inner = self.inner_mut();
+
+        match inner.try_reserve(count) {
+            Ok(reservation) => {
+                if let Some(send_future) = send_future.take() {
+                    inner.send_futures.remove(send_future);
+                }
+
+                Poll::Ready(Ok(reservation))
+            }
+            Err(TryReserveError::Full) => {
+                if send_future.is_none() {
+                    *send_future = Some(inner.send_futures.push_tail(SendWaker {
+                        count,
+                        waker: cx.waker().clone(),
+                    }));
+                }
+
+                Poll::Pending
+            }
+            Err(TryReserveError::Disconnected) => Poll::Ready(Err(ReserveError)),
+        }
+    }
+
+    pub fn send_with_permit(&self, reservation: NodeRef<Spot<T>>, value: T) {
+        let waker = {
+            let mut inner = self.inner_mut();
+            inner.queue.send(reservation, value);
+            inner.recv_futures.pop_head()
+            // TODO figure out if this is needed instead?
+            // inner.recv_futures.head().map(|waker| waker.clone())
+        };
+
+        if let Some(waker) = waker {
+            waker.wake()
+        }
+    }
+
+    pub fn drop_permit(&self, reservation: NodeRef<Spot<T>>, count: usize) {
+        let waker = {
+            let mut inner = self.inner_mut();
+
+            let released = inner.queue.release(reservation, count);
+
+            // When the permit was not used for sending, it means a spot was freed, so we can
+            // notify the next sender that it can proceed.
+            released
+                .then(|| {
+                    inner
+                        .send_futures
+                        .head()
+                        .filter(|send_waker| inner.queue.has_room_for(send_waker.count))
+                        .map(|send_waker| send_waker.clone())
+                })
+                .flatten()
+        };
+
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+
+    // fn drop_send_future(&self, fut: Option<NodeRef<SendWaker>>) {
+    //     let waker = {
+    //         let mut inner = self.inner_mut();
+
+    //         if let Some(fut) = fut {
+    //             inner.waiting_send_futures.remove(fut);
+    //             inner.reserved_count -= fut.count
+    //         }
+
+    //         // If there's room for the next sender in the queue, wake it.
+    //         match inner.waiting_send_futures.head() {
+    //             Some(next) => inner.has_room_for(next.count).then(|| next.waker.clone()),
+    //             None => None,
+    //         }
+    //     };
+
+    //     if let Some(waker) = waker {
+    //         waker.wake();
+    //     }
+    // }
+
+    // fn drop_recv_future(&self, id: &WakerId, has_received: bool) {
+    //     let waker = {
+    //         let mut inner = self.inner_mut();
+    //         let was_awoken = inner.waiting_recv_futures.remove(id).is_none();
+
+    //         // Wake another receiver in case this one has been awoken, but it was dropped before it
+    //         // managed to receive anything.
+    //         if was_awoken {
+    //             if has_received {
+    //                 // If we have received, it means a spot was freed in the internal buffer, so wake
+    //                 // one sender.
+    //                 inner.take_one_send_future_waker()
+    //             } else {
+    //                 // If we have not received, it means another RecvFuture might take over.
+    //                 inner.take_one_recv_future_waker()
+    //             }
+    //         } else {
+    //             None
+    //         }
+    //     };
+
+    //     if let Some(waker) = waker {
+    //         waker.wake();
+    //     }
+    // }
+}
+
+#[derive(Clone)]
+pub struct SendWaker {
+    count: usize,
+    waker: Waker,
+}
+
+impl SendWaker {
+    pub fn new(count: usize, waker: Waker) -> Self {
+        Self { count, waker }
+    }
+
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    pub fn wake(self) {
+        self.waker.wake()
+    }
+
+    pub fn wake_by_ref(&self) {
+        self.waker.wake_by_ref();
+    }
+}
+
+// TODO we need acustom impl of a LinkedList to be able to add/remove wakers, instead of using
+// WakerId.
+//
+// Moreover, currently reservations are just a counter, they don't actually take the
+// spot in the buffer, so in the case of a single consumer the result will be
+// re-ordered. We could keep an enum like this:
+//
+// ```
+// enum Spot<T> {
+//   Value(T),
+//   Reserved,
+// }
+// ```
+//
+// in the buffer so that we know we need to wait for the reservations.
+struct InnerState<T> {
+    queue: Queue<T>,
+    /// Total of created receivers.
+    receivers_count: usize,
+    /// Total of created senders.
+    senders_count: usize,
+    /// Senders waiting to send.
+    send_futures: LinkedList<SendWaker>,
+    /// Receivers waiting to receive.
+    recv_futures: LinkedList<Waker>,
+    /// False by default, true when all senders or all receivers are dropped.
+    disconnected: bool,
+}
+
+impl<T> InnerState<T>
+where
+    T: Send + Sync + 'static,
+{
+    pub fn new(cap: usize) -> Self {
+        Self {
+            queue: Queue::new(cap),
+            receivers_count: 0,
+            senders_count: 0,
+            send_futures: LinkedList::new(),
+            recv_futures: LinkedList::new(),
+            disconnected: false,
+        }
+    }
+
+    pub fn try_reserve(&mut self, count: usize) -> Result<NodeRef<Spot<T>>, TryReserveError> {
+        if self.disconnected {
+            Err(TryReserveError::Disconnected)
+        } else {
+            self.queue.try_reserve(count).ok_or(TryReserveError::Full)
+        }
+    }
+
+    // #[must_use]
+    // fn send_and_get_receiver_waker(
+    //     &mut self,
+    //     value: T,
+    //     waker: NodeRef<SendWaker>,
+    // ) -> Option<&Waker> {
+    //     self.buffer.push_back(value);
+    //     self.send_futures.remove(waker);
+    //     self.recv_futures.head()
+    // }
+
+    fn mark_disconnected_and_take_send_futures(&mut self) -> LinkedList<SendWaker> {
+        self.disconnected = true;
+        std::mem::take(&mut self.send_futures)
+    }
+
+    fn mark_disconnected_and_take_recv_futures(&mut self) -> LinkedList<Waker> {
+        self.disconnected = true;
+        std::mem::take(&mut self.recv_futures)
+    }
+
+    // #[must_use]
+    // fn take_one_send_future_waker(&mut self) -> Option<Waker> {
+    //     if self.has_room_for(1) {
+    //         Self::take_one_waker(&mut self.send_futures)
+    //     } else {
+    //         None
+    //     }
+    // }
+
+    // #[must_use]
+    // fn take_one_recv_future_waker(&mut self) -> Option<Waker> {
+    //     if !self.buffer.is_empty() {
+    //         Self::take_one_waker(&mut self.recv_futures)
+    //     } else {
+    //         None
+    //     }
+    // }
+
+    // #[must_use]
+    // fn take_one_waker(map: &mut BTreeMap<WakerId, Waker>) -> Option<Waker> {
+    //     map.pop_first().map(|(_, waker)| waker)
+    // }
+
+    // fn take_all_wakers(map: &mut BTreeMap<WakerId, Waker>) -> BTreeMap<WakerId, Waker> {
+    //     std::mem::take(map)
+    // }
+}

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+test_binary=$(cargo test --no-run --message-format json | jq -r '.executable | select( . != null )')
+
+exec valgrind --leak-check=full $test_binary


### PR DESCRIPTION
This allows us to use O(1) complexity for all operations. It removes the need for `BTreeMap`, `WakerId`s and `VecDeque`. All it takes to do a send/recv is to acquire a mutex and update the state on each end.

All existing tests pass, except there were a few that needed fixing due to more strict ordering: we're now respecting the ordering of operations: the first `Receiver::recv` call to be registered in the queue is guaranteed to receive a message from the first `Sender` or `Permit` call that's received on the other end.